### PR TITLE
Add lock timeout retries to apply

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -340,6 +340,9 @@ func RunApply(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("invalid --retry-interval: %w", err)
 	}
+	if applyRetryCount > 0 && retryInterval <= 0 {
+		return fmt.Errorf("--retry-interval must be positive when --retry-count is set")
+	}
 
 	// Build configuration
 	config := &ApplyConfig{
@@ -552,10 +555,12 @@ func execWithLockTimeoutRetry(ctx context.Context, conn *sql.DB, sqlStmt, descri
 			fmt.Printf("  Lock not available, retrying in %s (attempt %d/%d)...\n", retryInterval, attempt, retryCount)
 		}
 
+		timer := time.NewTimer(retryInterval)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return nil, ctx.Err()
-		case <-time.After(retryInterval):
+		case <-timer.C:
 		}
 
 		result, err = util.ExecContextWithLogging(ctx, conn, sqlStmt, description)

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -26,6 +26,18 @@ import (
 // statement fails to acquire a lock within lock_timeout.
 const lockNotAvailableSQLState = "55P03"
 
+// Lock timeout retries are automatic and not user-configurable: whenever
+// --lock-timeout is set, a statement that fails with a lock timeout is
+// retried with exponential backoff up to lockRetryMaxAttempts times. These
+// are declared as vars rather than consts purely so tests can shrink them
+// for fast execution; production code never overrides them.
+var (
+	lockRetryMaxAttempts    = 5
+	lockRetryInitialBackoff = 1 * time.Second
+)
+
+const lockRetryMaxBackoff = 30 * time.Second
+
 var (
 	applyHost            string
 	applyPort            int
@@ -38,8 +50,6 @@ var (
 	applyAutoApprove     bool
 	applyNoColor         bool
 	applyLockTimeout     string
-	applyRetryCount      int
-	applyRetryInterval   string
 	applyApplicationName string
 
 	// Plan database connection flags (optional - for using external database instead of embedded postgres)
@@ -80,9 +90,7 @@ func init() {
 	// Apply behavior flags
 	ApplyCmd.Flags().BoolVar(&applyAutoApprove, "auto-approve", false, "Apply changes without prompting for approval")
 	ApplyCmd.Flags().BoolVar(&applyNoColor, "no-color", false, "Disable colored output")
-	ApplyCmd.Flags().StringVar(&applyLockTimeout, "lock-timeout", "", "Maximum time to wait for database locks (e.g., 30s, 5m, 1h)")
-	ApplyCmd.Flags().IntVar(&applyRetryCount, "retry-count", 0, "Number of times to retry a statement that fails to acquire a lock within --lock-timeout (default 0 disables retries)")
-	ApplyCmd.Flags().StringVar(&applyRetryInterval, "retry-interval", "1s", "Time to wait between retries after a lock timeout (e.g., 1s, 500ms)")
+	ApplyCmd.Flags().StringVar(&applyLockTimeout, "lock-timeout", "", "Maximum time to wait for database locks (e.g., 30s, 5m, 1h). When set, a statement that fails to acquire a lock is automatically retried with exponential backoff")
 	ApplyCmd.Flags().StringVar(&applyApplicationName, "application-name", "pgschema", "Application name for database connection (visible in pg_stat_activity) (env: PGAPPNAME)")
 
 	// Plan database connection flags (optional - for using external database instead of embedded postgres when using --file)
@@ -112,10 +120,8 @@ type ApplyConfig struct {
 	Plan            *plan.Plan // Pre-generated plan (optional, alternative to File)
 	AutoApprove     bool
 	NoColor         bool
-	Quiet           bool // Suppress plan display and progress messages (useful for tests)
-	LockTimeout     string
-	RetryCount      int           // Number of retries for statements that fail to acquire a lock within LockTimeout
-	RetryInterval   time.Duration // Time to wait between retries
+	Quiet           bool   // Suppress plan display and progress messages (useful for tests)
+	LockTimeout     string // When set, lock timeout failures are automatically retried with exponential backoff
 	ApplicationName string
 	SSLMode         string
 	// Plan database configuration (needed when GeneratePlan checks provider SSL mode)
@@ -260,13 +266,21 @@ func ApplyMigration(config *ApplyConfig, provider postgres.DesiredStateProvider)
 		return nil
 	}
 
+	// Lock timeout retries are only meaningful alongside a lock timeout:
+	// without one, a blocked statement waits indefinitely instead of failing
+	// with a retryable error.
+	var retry lockRetryConfig
+	if config.LockTimeout != "" {
+		retry = lockRetryConfig{MaxRetries: lockRetryMaxAttempts, Backoff: lockRetryInitialBackoff}
+	}
+
 	// Execute by groups with wait directive support
 	for i, group := range migrationPlan.Groups {
 		if !config.Quiet {
 			fmt.Printf("\nExecuting group %d/%d...\n", i+1, len(migrationPlan.Groups))
 		}
 
-		err = executeGroup(ctx, conn, group, i+1, config.Quiet, config.RetryCount, config.RetryInterval)
+		err = executeGroup(ctx, conn, group, i+1, config.Quiet, retry)
 		if err != nil {
 			return err
 		}
@@ -329,21 +343,6 @@ func RunApply(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Validate retry configuration
-	if applyRetryCount < 0 {
-		return fmt.Errorf("--retry-count must be zero or positive")
-	}
-	if applyRetryCount > 0 && applyLockTimeout == "" {
-		return fmt.Errorf("--retry-count requires --lock-timeout to be set")
-	}
-	retryInterval, err := time.ParseDuration(applyRetryInterval)
-	if err != nil {
-		return fmt.Errorf("invalid --retry-interval: %w", err)
-	}
-	if applyRetryCount > 0 && retryInterval <= 0 {
-		return fmt.Errorf("--retry-interval must be positive when --retry-count is set")
-	}
-
 	// Build configuration
 	config := &ApplyConfig{
 		Host:            applyHost,
@@ -355,12 +354,11 @@ func RunApply(cmd *cobra.Command, args []string) error {
 		AutoApprove:     applyAutoApprove,
 		NoColor:         applyNoColor,
 		LockTimeout:     applyLockTimeout,
-		RetryCount:      applyRetryCount,
-		RetryInterval:   retryInterval,
 		ApplicationName: applyApplicationName,
 		SSLMode:         finalSSLMode,
 	}
 
+	var err error
 	var provider postgres.DesiredStateProvider
 
 	// If using --plan flag, load plan from JSON file
@@ -473,7 +471,7 @@ func validateSchemaFingerprint(migrationPlan *plan.Plan, host string, port int, 
 }
 
 // executeGroup executes all steps in a group, handling directives separately from SQL statements
-func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retryCount int, retryInterval time.Duration) error {
+func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retry lockRetryConfig) error {
 	// Check if this group has directives
 	hasDirectives := false
 
@@ -486,7 +484,7 @@ func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, 
 
 	if !hasDirectives {
 		// No directives - concatenate all SQL and execute in implicit transaction
-		return executeGroupConcatenated(ctx, conn, group, groupNum, quiet, retryCount, retryInterval)
+		return executeGroupConcatenated(ctx, conn, group, groupNum, quiet, retry)
 	} else {
 		// Has directives (e.g. waiting for a concurrent index build to finish) -
 		// execute statements individually. These are status-check queries, not
@@ -496,7 +494,7 @@ func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, 
 }
 
 // executeGroupConcatenated concatenates all SQL statements and executes them in an implicit transaction
-func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retryCount int, retryInterval time.Duration) error {
+func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retry lockRetryConfig) error {
 	var sqlStatements []string
 
 	// Collect all SQL statements
@@ -519,12 +517,12 @@ func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.Exec
 	// partial catalog state (e.g. an invalid index) behind on failure; retrying
 	// the same "IF NOT EXISTS" statement could silently skip over that partial
 	// state instead of surfacing the failure, so those are never retried.
-	effectiveRetryCount := retryCount
+	effectiveRetry := retry
 	if containsConcurrentStatement(sqlStatements) {
-		effectiveRetryCount = 0
+		effectiveRetry = lockRetryConfig{}
 	}
 
-	_, err := execWithLockTimeoutRetry(ctx, conn, concatenatedSQL, fmt.Sprintf("execute %d statements in group %d", len(sqlStatements), groupNum), effectiveRetryCount, retryInterval, quiet)
+	_, err := execWithLockTimeoutRetry(ctx, conn, concatenatedSQL, fmt.Sprintf("execute %d statements in group %d", len(sqlStatements), groupNum), effectiveRetry, quiet)
 	if err != nil {
 		return fmt.Errorf("failed to execute concatenated statements in group %d: %w", groupNum, err)
 	}
@@ -556,18 +554,32 @@ func executeGroupIndividually(ctx context.Context, conn *sql.DB, group plan.Exec
 	return nil
 }
 
-// execWithLockTimeoutRetry executes sqlStmt, retrying up to retryCount times
-// (waiting retryInterval between attempts) when the failure is a PostgreSQL
+// lockRetryConfig controls retry behavior for statements that fail because they
+// could not acquire a lock before lock_timeout expired (SQLSTATE 55P03). A
+// zero-value lockRetryConfig (MaxRetries: 0) disables retries.
+type lockRetryConfig struct {
+	MaxRetries int           // Number of additional attempts after the first failure
+	Backoff    time.Duration // Initial wait before the first retry; doubles after each subsequent retry
+}
+
+// execWithLockTimeoutRetry executes sqlStmt, retrying with exponential backoff
+// (capped at lockRetryMaxBackoff) when the failure is a PostgreSQL
 // lock_not_available error (SQLSTATE 55P03), i.e. the statement could not
 // acquire a lock within --lock-timeout. Any other error is returned immediately.
-func execWithLockTimeoutRetry(ctx context.Context, conn *sql.DB, sqlStmt, description string, retryCount int, retryInterval time.Duration, quiet bool) (sql.Result, error) {
-	result, err := util.ExecContextWithLogging(ctx, conn, sqlStmt, description)
-	for attempt := 1; err != nil && attempt <= retryCount && isLockNotAvailableError(err); attempt++ {
-		if !quiet {
-			fmt.Printf("  Lock not available, retrying in %s (attempt %d/%d)...\n", retryInterval, attempt, retryCount)
+func execWithLockTimeoutRetry(ctx context.Context, conn *sql.DB, sqlStmt, description string, retry lockRetryConfig, quiet bool) (sql.Result, error) {
+	backoff := retry.Backoff
+
+	for attempt := 0; ; attempt++ {
+		result, err := util.ExecContextWithLogging(ctx, conn, sqlStmt, description)
+		if err == nil || !isLockNotAvailableError(err) || attempt >= retry.MaxRetries {
+			return result, err
 		}
 
-		timer := time.NewTimer(retryInterval)
+		if !quiet {
+			fmt.Printf("  Lock not available, retrying in %s (retry %d/%d)...\n", backoff, attempt+1, retry.MaxRetries)
+		}
+
+		timer := time.NewTimer(backoff)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
@@ -575,9 +587,11 @@ func execWithLockTimeoutRetry(ctx context.Context, conn *sql.DB, sqlStmt, descri
 		case <-timer.C:
 		}
 
-		result, err = util.ExecContextWithLogging(ctx, conn, sqlStmt, description)
+		backoff *= 2
+		if backoff > lockRetryMaxBackoff {
+			backoff = lockRetryMaxBackoff
+		}
 	}
-	return result, err
 }
 
 // containsConcurrentStatement reports whether any statement uses CONCURRENTLY

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -271,7 +271,13 @@ func ApplyMigration(config *ApplyConfig, provider postgres.DesiredStateProvider)
 	// with a retryable error.
 	var retry lockRetryConfig
 	if config.LockTimeout != "" {
-		retry = lockRetryConfig{MaxRetries: lockRetryMaxAttempts, Backoff: lockRetryInitialBackoff}
+		// lockRetryMaxAttempts counts the first attempt too, but MaxRetries
+		// counts only the retries after it, so convert between the two.
+		maxRetries := lockRetryMaxAttempts - 1
+		if maxRetries < 0 {
+			maxRetries = 0
+		}
+		retry = lockRetryConfig{MaxRetries: maxRetries, Backoff: lockRetryInitialBackoff}
 	}
 
 	// Execute by groups with wait directive support

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -81,7 +81,7 @@ func init() {
 	ApplyCmd.Flags().BoolVar(&applyAutoApprove, "auto-approve", false, "Apply changes without prompting for approval")
 	ApplyCmd.Flags().BoolVar(&applyNoColor, "no-color", false, "Disable colored output")
 	ApplyCmd.Flags().StringVar(&applyLockTimeout, "lock-timeout", "", "Maximum time to wait for database locks (e.g., 30s, 5m, 1h)")
-	ApplyCmd.Flags().IntVar(&applyRetryCount, "retry-count", 0, "Number of times to retry a statement that fails to acquire a lock within --lock-timeout (default 0 disables retries)")
+	ApplyCmd.Flags().IntVar(&applyRetryCount, "retry-count", 0, "Number of times to retry a group of statements that fails to acquire a lock within --lock-timeout (default 0 disables retries; not applied to CREATE INDEX CONCURRENTLY)")
 	ApplyCmd.Flags().StringVar(&applyRetryInterval, "retry-interval", "1s", "Time to wait between retries after a lock timeout (e.g., 1s, 500ms)")
 	ApplyCmd.Flags().StringVar(&applyApplicationName, "application-name", "pgschema", "Application name for database connection (visible in pg_stat_activity) (env: PGAPPNAME)")
 

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -32,7 +32,7 @@ const lockNotAvailableSQLState = "55P03"
 // are declared as vars rather than consts purely so tests can shrink them
 // for fast execution; production code never overrides them.
 var (
-	lockRetryMaxAttempts    = 5
+	lockRetryMaxAttempts    = 3
 	lockRetryInitialBackoff = 1 * time.Second
 )
 

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -493,8 +493,9 @@ func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, 
 		return executeGroupConcatenated(ctx, conn, group, groupNum, quiet, retry)
 	} else {
 		// Has directives (e.g. waiting for a concurrent index build to finish) -
-		// execute statements individually. These are status-check queries, not
-		// DDL, so lock-timeout retries don't apply here.
+		// execute statements individually rather than batched in one implicit
+		// transaction, so lock-timeout retries (safe only when a retry can
+		// re-apply the whole batch atomically) don't apply here.
 		return executeGroupIndividually(ctx, conn, group, groupNum, quiet)
 	}
 }

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -4,11 +4,14 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	planCmd "github.com/pgplex/pgschema/cmd/plan"
 	"github.com/pgplex/pgschema/cmd/util"
 	"github.com/pgplex/pgschema/internal/fingerprint"
@@ -18,6 +21,10 @@ import (
 	"github.com/pgplex/pgschema/ir"
 	"github.com/spf13/cobra"
 )
+
+// lockNotAvailableSQLState is the PostgreSQL SQLSTATE code raised when a
+// statement fails to acquire a lock within lock_timeout.
+const lockNotAvailableSQLState = "55P03"
 
 var (
 	applyHost            string
@@ -31,6 +38,8 @@ var (
 	applyAutoApprove     bool
 	applyNoColor         bool
 	applyLockTimeout     string
+	applyRetryCount      int
+	applyRetryInterval   string
 	applyApplicationName string
 
 	// Plan database connection flags (optional - for using external database instead of embedded postgres)
@@ -72,6 +81,8 @@ func init() {
 	ApplyCmd.Flags().BoolVar(&applyAutoApprove, "auto-approve", false, "Apply changes without prompting for approval")
 	ApplyCmd.Flags().BoolVar(&applyNoColor, "no-color", false, "Disable colored output")
 	ApplyCmd.Flags().StringVar(&applyLockTimeout, "lock-timeout", "", "Maximum time to wait for database locks (e.g., 30s, 5m, 1h)")
+	ApplyCmd.Flags().IntVar(&applyRetryCount, "retry-count", 0, "Number of times to retry a statement that fails to acquire a lock within --lock-timeout (default 0 disables retries)")
+	ApplyCmd.Flags().StringVar(&applyRetryInterval, "retry-interval", "1s", "Time to wait between retries after a lock timeout (e.g., 1s, 500ms)")
 	ApplyCmd.Flags().StringVar(&applyApplicationName, "application-name", "pgschema", "Application name for database connection (visible in pg_stat_activity) (env: PGAPPNAME)")
 
 	// Plan database connection flags (optional - for using external database instead of embedded postgres when using --file)
@@ -103,6 +114,8 @@ type ApplyConfig struct {
 	NoColor         bool
 	Quiet           bool // Suppress plan display and progress messages (useful for tests)
 	LockTimeout     string
+	RetryCount      int           // Number of retries for statements that fail to acquire a lock within LockTimeout
+	RetryInterval   time.Duration // Time to wait between retries
 	ApplicationName string
 	SSLMode         string
 	// Plan database configuration (needed when GeneratePlan checks provider SSL mode)
@@ -253,7 +266,7 @@ func ApplyMigration(config *ApplyConfig, provider postgres.DesiredStateProvider)
 			fmt.Printf("\nExecuting group %d/%d...\n", i+1, len(migrationPlan.Groups))
 		}
 
-		err = executeGroup(ctx, conn, group, i+1, config.Quiet)
+		err = executeGroup(ctx, conn, group, i+1, config.Quiet, config.RetryCount, config.RetryInterval)
 		if err != nil {
 			return err
 		}
@@ -316,6 +329,18 @@ func RunApply(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Validate retry configuration
+	if applyRetryCount < 0 {
+		return fmt.Errorf("--retry-count must be zero or positive")
+	}
+	if applyRetryCount > 0 && applyLockTimeout == "" {
+		return fmt.Errorf("--retry-count requires --lock-timeout to be set")
+	}
+	retryInterval, err := time.ParseDuration(applyRetryInterval)
+	if err != nil {
+		return fmt.Errorf("invalid --retry-interval: %w", err)
+	}
+
 	// Build configuration
 	config := &ApplyConfig{
 		Host:            applyHost,
@@ -327,12 +352,13 @@ func RunApply(cmd *cobra.Command, args []string) error {
 		AutoApprove:     applyAutoApprove,
 		NoColor:         applyNoColor,
 		LockTimeout:     applyLockTimeout,
+		RetryCount:      applyRetryCount,
+		RetryInterval:   retryInterval,
 		ApplicationName: applyApplicationName,
 		SSLMode:         finalSSLMode,
 	}
 
 	var provider postgres.DesiredStateProvider
-	var err error
 
 	// If using --plan flag, load plan from JSON file
 	if applyPlan != "" {
@@ -444,7 +470,7 @@ func validateSchemaFingerprint(migrationPlan *plan.Plan, host string, port int, 
 }
 
 // executeGroup executes all steps in a group, handling directives separately from SQL statements
-func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool) error {
+func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retryCount int, retryInterval time.Duration) error {
 	// Check if this group has directives
 	hasDirectives := false
 
@@ -457,15 +483,15 @@ func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, 
 
 	if !hasDirectives {
 		// No directives - concatenate all SQL and execute in implicit transaction
-		return executeGroupConcatenated(ctx, conn, group, groupNum, quiet)
+		return executeGroupConcatenated(ctx, conn, group, groupNum, quiet, retryCount, retryInterval)
 	} else {
 		// Has directives - execute statements individually
-		return executeGroupIndividually(ctx, conn, group, groupNum, quiet)
+		return executeGroupIndividually(ctx, conn, group, groupNum, quiet, retryCount, retryInterval)
 	}
 }
 
 // executeGroupConcatenated concatenates all SQL statements and executes them in an implicit transaction
-func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool) error {
+func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retryCount int, retryInterval time.Duration) error {
 	var sqlStatements []string
 
 	// Collect all SQL statements
@@ -480,8 +506,10 @@ func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.Exec
 		fmt.Printf("  Executing %d statements in implicit transaction\n", len(sqlStatements))
 	}
 
-	// Execute all statements in a single call (implicit transaction)
-	_, err := util.ExecContextWithLogging(ctx, conn, concatenatedSQL, fmt.Sprintf("execute %d statements in group %d", len(sqlStatements), groupNum))
+	// Execute all statements in a single call (implicit transaction). Since the
+	// statements run as one implicit transaction, either all of them apply or
+	// none do, so it is safe to retry the whole batch on a lock timeout.
+	_, err := execWithLockTimeoutRetry(ctx, conn, concatenatedSQL, fmt.Sprintf("execute %d statements in group %d", len(sqlStatements), groupNum), retryCount, retryInterval, quiet)
 	if err != nil {
 		return fmt.Errorf("failed to execute concatenated statements in group %d: %w", groupNum, err)
 	}
@@ -490,7 +518,7 @@ func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.Exec
 }
 
 // executeGroupIndividually executes statements individually without transactions
-func executeGroupIndividually(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool) error {
+func executeGroupIndividually(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retryCount int, retryInterval time.Duration) error {
 	for stepIdx, step := range group.Steps {
 		if step.Directive != nil {
 			// Handle directive execution
@@ -504,13 +532,42 @@ func executeGroupIndividually(ctx context.Context, conn *sql.DB, group plan.Exec
 				fmt.Printf("  Executing: %s\n", truncateSQL(step.SQL, 80))
 			}
 
-			_, err := util.ExecContextWithLogging(ctx, conn, step.SQL, fmt.Sprintf("execute statement in group %d, step %d", groupNum, stepIdx+1))
+			_, err := execWithLockTimeoutRetry(ctx, conn, step.SQL, fmt.Sprintf("execute statement in group %d, step %d", groupNum, stepIdx+1), retryCount, retryInterval, quiet)
 			if err != nil {
 				return fmt.Errorf("failed to execute statement in group %d, step %d: %w", groupNum, stepIdx+1, err)
 			}
 		}
 	}
 	return nil
+}
+
+// execWithLockTimeoutRetry executes sqlStmt, retrying up to retryCount times
+// (waiting retryInterval between attempts) when the failure is a PostgreSQL
+// lock_not_available error (SQLSTATE 55P03), i.e. the statement could not
+// acquire a lock within --lock-timeout. Any other error is returned immediately.
+func execWithLockTimeoutRetry(ctx context.Context, conn *sql.DB, sqlStmt, description string, retryCount int, retryInterval time.Duration, quiet bool) (sql.Result, error) {
+	result, err := util.ExecContextWithLogging(ctx, conn, sqlStmt, description)
+	for attempt := 1; err != nil && attempt <= retryCount && isLockNotAvailableError(err); attempt++ {
+		if !quiet {
+			fmt.Printf("  Lock not available, retrying in %s (attempt %d/%d)...\n", retryInterval, attempt, retryCount)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(retryInterval):
+		}
+
+		result, err = util.ExecContextWithLogging(ctx, conn, sqlStmt, description)
+	}
+	return result, err
+}
+
+// isLockNotAvailableError reports whether err is a PostgreSQL error raised
+// because a statement could not acquire a lock within lock_timeout.
+func isLockNotAvailableError(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == lockNotAvailableSQLState
 }
 
 // truncateSQL truncates a SQL statement for display purposes

--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -488,8 +488,10 @@ func executeGroup(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, 
 		// No directives - concatenate all SQL and execute in implicit transaction
 		return executeGroupConcatenated(ctx, conn, group, groupNum, quiet, retryCount, retryInterval)
 	} else {
-		// Has directives - execute statements individually
-		return executeGroupIndividually(ctx, conn, group, groupNum, quiet, retryCount, retryInterval)
+		// Has directives (e.g. waiting for a concurrent index build to finish) -
+		// execute statements individually. These are status-check queries, not
+		// DDL, so lock-timeout retries don't apply here.
+		return executeGroupIndividually(ctx, conn, group, groupNum, quiet)
 	}
 }
 
@@ -511,8 +513,18 @@ func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.Exec
 
 	// Execute all statements in a single call (implicit transaction). Since the
 	// statements run as one implicit transaction, either all of them apply or
-	// none do, so it is safe to retry the whole batch on a lock timeout.
-	_, err := execWithLockTimeoutRetry(ctx, conn, concatenatedSQL, fmt.Sprintf("execute %d statements in group %d", len(sqlStatements), groupNum), retryCount, retryInterval, quiet)
+	// none do, so it is safe to retry the whole batch on a lock timeout - unless
+	// the batch contains a CONCURRENTLY statement (e.g. CREATE INDEX CONCURRENTLY).
+	// Such statements build in multiple internal sub-transactions and can leave
+	// partial catalog state (e.g. an invalid index) behind on failure; retrying
+	// the same "IF NOT EXISTS" statement could silently skip over that partial
+	// state instead of surfacing the failure, so those are never retried.
+	effectiveRetryCount := retryCount
+	if containsConcurrentStatement(sqlStatements) {
+		effectiveRetryCount = 0
+	}
+
+	_, err := execWithLockTimeoutRetry(ctx, conn, concatenatedSQL, fmt.Sprintf("execute %d statements in group %d", len(sqlStatements), groupNum), effectiveRetryCount, retryInterval, quiet)
 	if err != nil {
 		return fmt.Errorf("failed to execute concatenated statements in group %d: %w", groupNum, err)
 	}
@@ -521,7 +533,7 @@ func executeGroupConcatenated(ctx context.Context, conn *sql.DB, group plan.Exec
 }
 
 // executeGroupIndividually executes statements individually without transactions
-func executeGroupIndividually(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool, retryCount int, retryInterval time.Duration) error {
+func executeGroupIndividually(ctx context.Context, conn *sql.DB, group plan.ExecutionGroup, groupNum int, quiet bool) error {
 	for stepIdx, step := range group.Steps {
 		if step.Directive != nil {
 			// Handle directive execution
@@ -535,7 +547,7 @@ func executeGroupIndividually(ctx context.Context, conn *sql.DB, group plan.Exec
 				fmt.Printf("  Executing: %s\n", truncateSQL(step.SQL, 80))
 			}
 
-			_, err := execWithLockTimeoutRetry(ctx, conn, step.SQL, fmt.Sprintf("execute statement in group %d, step %d", groupNum, stepIdx+1), retryCount, retryInterval, quiet)
+			_, err := util.ExecContextWithLogging(ctx, conn, step.SQL, fmt.Sprintf("execute statement in group %d, step %d", groupNum, stepIdx+1))
 			if err != nil {
 				return fmt.Errorf("failed to execute statement in group %d, step %d: %w", groupNum, stepIdx+1, err)
 			}
@@ -566,6 +578,18 @@ func execWithLockTimeoutRetry(ctx context.Context, conn *sql.DB, sqlStmt, descri
 		result, err = util.ExecContextWithLogging(ctx, conn, sqlStmt, description)
 	}
 	return result, err
+}
+
+// containsConcurrentStatement reports whether any statement uses CONCURRENTLY
+// (e.g. CREATE INDEX CONCURRENTLY), which builds across multiple internal
+// sub-transactions and is not safe to blindly retry as a whole on failure.
+func containsConcurrentStatement(statements []string) bool {
+	for _, stmt := range statements {
+		if strings.Contains(strings.ToUpper(stmt), "CONCURRENTLY") {
+			return true
+		}
+	}
+	return false
 }
 
 // isLockNotAvailableError reports whether err is a PostgreSQL error raised

--- a/cmd/apply/apply_integration_test.go
+++ b/cmd/apply/apply_integration_test.go
@@ -1346,15 +1346,32 @@ CREATE TABLE users (
 	assert.Equal(t, "users", tableName, "table should be created")
 }
 
+// withLockRetryTuning shrinks the package-level lock retry defaults for the
+// duration of a test so integration tests don't have to wait out the real
+// production backoff schedule (up to lockRetryMaxBackoff between retries).
+func withLockRetryTuning(t *testing.T, maxAttempts int, initialBackoff time.Duration) {
+	t.Helper()
+	origMaxAttempts := lockRetryMaxAttempts
+	origInitialBackoff := lockRetryInitialBackoff
+	lockRetryMaxAttempts = maxAttempts
+	lockRetryInitialBackoff = initialBackoff
+	t.Cleanup(func() {
+		lockRetryMaxAttempts = origMaxAttempts
+		lockRetryInitialBackoff = origInitialBackoff
+	})
+}
+
 // TestApplyCommand_LockTimeoutRetrySucceeds verifies that a statement blocked
-// by a lock held by another session eventually succeeds when --retry-count
-// gives it enough attempts to outlast the blocker, per the zero-downtime
+// by a lock held by another session eventually succeeds once the automatic
+// lock-timeout retry (exponential backoff, enabled whenever --lock-timeout is
+// set) gives it enough attempts to outlast the blocker, per the zero-downtime
 // migration pattern of a short --lock-timeout combined with retries (see
 // https://github.com/pgplex/pgschema/issues/557).
 func TestApplyCommand_LockTimeoutRetrySucceeds(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	withLockRetryTuning(t, 10, 100*time.Millisecond)
 
 	ctx := context.Background()
 
@@ -1421,8 +1438,6 @@ func TestApplyCommand_LockTimeoutRetrySucceeds(t *testing.T) {
 		AutoApprove:     true,
 		Quiet:           true,
 		LockTimeout:     "200ms",
-		RetryCount:      10,
-		RetryInterval:   200 * time.Millisecond,
 		ApplicationName: "pgschema",
 	}
 
@@ -1440,13 +1455,14 @@ func TestApplyCommand_LockTimeoutRetrySucceeds(t *testing.T) {
 	assert.True(t, priceColumnExists, "price column should exist once the retried apply succeeds")
 }
 
-// TestApplyCommand_LockTimeoutRetryExhausted verifies that once the configured
-// number of retries is exhausted without acquiring the lock, ApplyMigration
-// surfaces the lock timeout error and does not apply any change.
+// TestApplyCommand_LockTimeoutRetryExhausted verifies that once the automatic
+// retries are exhausted without acquiring the lock, ApplyMigration surfaces
+// the lock timeout error and does not apply any change.
 func TestApplyCommand_LockTimeoutRetryExhausted(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	withLockRetryTuning(t, 2, 50*time.Millisecond)
 
 	ctx := context.Background()
 
@@ -1502,8 +1518,6 @@ func TestApplyCommand_LockTimeoutRetryExhausted(t *testing.T) {
 		AutoApprove:     true,
 		Quiet:           true,
 		LockTimeout:     "150ms",
-		RetryCount:      2,
-		RetryInterval:   150 * time.Millisecond,
 		ApplicationName: "pgschema",
 	}
 
@@ -1533,6 +1547,10 @@ func TestApplyCommand_LockTimeoutRetryNotAppliedToConcurrentIndex(t *testing.T) 
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	// A large backoff: if this statement were mistakenly retried, the test
+	// would blow past the elapsed-time assertion below instead of passing
+	// vacuously.
+	withLockRetryTuning(t, 5, 5*time.Second)
 
 	ctx := context.Background()
 
@@ -1592,8 +1610,6 @@ func TestApplyCommand_LockTimeoutRetryNotAppliedToConcurrentIndex(t *testing.T) 
 		AutoApprove:     true,
 		Quiet:           true,
 		LockTimeout:     "150ms",
-		RetryCount:      5,
-		RetryInterval:   2 * time.Second,
 		ApplicationName: "pgschema",
 	}
 

--- a/cmd/apply/apply_integration_test.go
+++ b/cmd/apply/apply_integration_test.go
@@ -1521,3 +1521,86 @@ func TestApplyCommand_LockTimeoutRetryExhausted(t *testing.T) {
 	require.NoError(t, scanErr)
 	assert.False(t, priceColumnExists, "price column should not exist after the apply failed")
 }
+
+// TestApplyCommand_LockTimeoutRetryNotAppliedToConcurrentIndex verifies that
+// lock-timeout retries are NOT applied to statements executed individually
+// outside a transaction, such as CREATE INDEX CONCURRENTLY. Those statements
+// run with "IF NOT EXISTS", so blindly retrying after a partial failure could
+// silently skip rebuilding a leftover invalid index instead of surfacing the
+// failure. The apply should fail after a single lock-timeout attempt rather
+// than retrying.
+func TestApplyCommand_LockTimeoutRetryNotAppliedToConcurrentIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	_, err := conn.ExecContext(ctx, `CREATE TABLE items (id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL)`)
+	require.NoError(t, err, "should create initial schema")
+
+	tmpDir := t.TempDir()
+	desiredStateFile := filepath.Join(tmpDir, "desired_state.sql")
+	desiredStateSQL := `
+		CREATE TABLE items (
+			id SERIAL PRIMARY KEY,
+			name VARCHAR(255) NOT NULL
+		);
+
+		CREATE INDEX idx_items_name ON public.items USING btree (name);
+	`
+	require.NoError(t, os.WriteFile(desiredStateFile, []byte(desiredStateSQL), 0644))
+
+	planConfig := &planCmd.PlanConfig{
+		Host:            host,
+		Port:            port,
+		DB:              dbname,
+		User:            user,
+		Password:        password,
+		Schema:          "public",
+		File:            desiredStateFile,
+		ApplicationName: "pgschema",
+	}
+	migrationPlan, err := planCmd.GeneratePlan(planConfig, sharedEmbeddedPG)
+	require.NoError(t, err, "should generate migration plan")
+	require.Contains(t, migrationPlan.ToSQL(plan.SQLFormatRaw), "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_items_name")
+
+	// Hold a lock strong enough to block CREATE INDEX CONCURRENTLY's initial
+	// lock acquisition, and never release it during the test.
+	blockerConn, err := util.Connect(&util.ConnectionConfig{
+		Host: host, Port: port, Database: dbname, User: user, Password: password,
+		SSLMode: "prefer", ApplicationName: "pgschema-test-blocker",
+	})
+	require.NoError(t, err)
+	defer blockerConn.Close()
+
+	blockerTx, err := blockerConn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = blockerTx.ExecContext(ctx, `LOCK TABLE items IN SHARE UPDATE EXCLUSIVE MODE`)
+	require.NoError(t, err, "should acquire a conflicting lock on items")
+	defer blockerTx.Rollback()
+
+	applyConfig := &ApplyConfig{
+		Host: host, Port: port, DB: dbname, User: user, Password: password,
+		Schema:          "public",
+		Plan:            migrationPlan,
+		AutoApprove:     true,
+		Quiet:           true,
+		LockTimeout:     "150ms",
+		RetryCount:      5,
+		RetryInterval:   2 * time.Second,
+		ApplicationName: "pgschema",
+	}
+
+	start := time.Now()
+	err = ApplyMigration(applyConfig, nil)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "apply should fail since the lock is never released")
+	assert.Less(t, elapsed, 1*time.Second, "apply should fail after a single lock-timeout attempt, not after waiting out any retry-interval")
+}

--- a/cmd/apply/apply_integration_test.go
+++ b/cmd/apply/apply_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	planCmd "github.com/pgplex/pgschema/cmd/plan"
 	"github.com/pgplex/pgschema/cmd/util"
@@ -1343,4 +1344,180 @@ CREATE TABLE users (
 	err = targetConn.QueryRow("SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename = 'users'").Scan(&tableName)
 	require.NoError(t, err, "should find users table")
 	assert.Equal(t, "users", tableName, "table should be created")
+}
+
+// TestApplyCommand_LockTimeoutRetrySucceeds verifies that a statement blocked
+// by a lock held by another session eventually succeeds when --retry-count
+// gives it enough attempts to outlast the blocker, per the zero-downtime
+// migration pattern of a short --lock-timeout combined with retries (see
+// https://github.com/pgplex/pgschema/issues/557).
+func TestApplyCommand_LockTimeoutRetrySucceeds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	_, err := conn.ExecContext(ctx, `CREATE TABLE items (id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL)`)
+	require.NoError(t, err, "should create initial schema")
+
+	tmpDir := t.TempDir()
+	desiredStateFile := filepath.Join(tmpDir, "desired_state.sql")
+	desiredStateSQL := `
+		CREATE TABLE items (
+			id SERIAL PRIMARY KEY,
+			name VARCHAR(255) NOT NULL,
+			price DECIMAL(10, 2)
+		);
+	`
+	require.NoError(t, os.WriteFile(desiredStateFile, []byte(desiredStateSQL), 0644))
+
+	planConfig := &planCmd.PlanConfig{
+		Host:            host,
+		Port:            port,
+		DB:              dbname,
+		User:            user,
+		Password:        password,
+		Schema:          "public",
+		File:            desiredStateFile,
+		ApplicationName: "pgschema",
+	}
+	migrationPlan, err := planCmd.GeneratePlan(planConfig, sharedEmbeddedPG)
+	require.NoError(t, err, "should generate migration plan")
+	require.Contains(t, migrationPlan.ToSQL(plan.SQLFormatRaw), "ALTER TABLE items ADD COLUMN price")
+
+	// Open a second connection and hold a conflicting lock on items so the
+	// upcoming ALTER TABLE (which needs ACCESS EXCLUSIVE) cannot proceed
+	// immediately.
+	blockerConn, err := util.Connect(&util.ConnectionConfig{
+		Host: host, Port: port, Database: dbname, User: user, Password: password,
+		SSLMode: "prefer", ApplicationName: "pgschema-test-blocker",
+	})
+	require.NoError(t, err)
+	defer blockerConn.Close()
+
+	blockerTx, err := blockerConn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = blockerTx.ExecContext(ctx, `SELECT * FROM items`)
+	require.NoError(t, err, "should acquire a lock on items via the blocking transaction")
+
+	// Release the lock partway through the retry budget so the first attempt
+	// (and possibly a few retries) fail, but a later retry succeeds.
+	releaseAfter := 700 * time.Millisecond
+	go func() {
+		time.Sleep(releaseAfter)
+		_ = blockerTx.Commit()
+	}()
+
+	applyConfig := &ApplyConfig{
+		Host: host, Port: port, DB: dbname, User: user, Password: password,
+		Schema:          "public",
+		Plan:            migrationPlan,
+		AutoApprove:     true,
+		Quiet:           true,
+		LockTimeout:     "200ms",
+		RetryCount:      10,
+		RetryInterval:   200 * time.Millisecond,
+		ApplicationName: "pgschema",
+	}
+
+	err = ApplyMigration(applyConfig, nil)
+	require.NoError(t, err, "apply should retry past the lock timeout and eventually succeed")
+
+	var priceColumnExists bool
+	err = conn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'items' AND column_name = 'price'
+		)
+	`).Scan(&priceColumnExists)
+	require.NoError(t, err)
+	assert.True(t, priceColumnExists, "price column should exist once the retried apply succeeds")
+}
+
+// TestApplyCommand_LockTimeoutRetryExhausted verifies that once the configured
+// number of retries is exhausted without acquiring the lock, ApplyMigration
+// surfaces the lock timeout error and does not apply any change.
+func TestApplyCommand_LockTimeoutRetryExhausted(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	_, err := conn.ExecContext(ctx, `CREATE TABLE items (id SERIAL PRIMARY KEY, name VARCHAR(255) NOT NULL)`)
+	require.NoError(t, err, "should create initial schema")
+
+	tmpDir := t.TempDir()
+	desiredStateFile := filepath.Join(tmpDir, "desired_state.sql")
+	desiredStateSQL := `
+		CREATE TABLE items (
+			id SERIAL PRIMARY KEY,
+			name VARCHAR(255) NOT NULL,
+			price DECIMAL(10, 2)
+		);
+	`
+	require.NoError(t, os.WriteFile(desiredStateFile, []byte(desiredStateSQL), 0644))
+
+	planConfig := &planCmd.PlanConfig{
+		Host:            host,
+		Port:            port,
+		DB:              dbname,
+		User:            user,
+		Password:        password,
+		Schema:          "public",
+		File:            desiredStateFile,
+		ApplicationName: "pgschema",
+	}
+	migrationPlan, err := planCmd.GeneratePlan(planConfig, sharedEmbeddedPG)
+	require.NoError(t, err, "should generate migration plan")
+
+	blockerConn, err := util.Connect(&util.ConnectionConfig{
+		Host: host, Port: port, Database: dbname, User: user, Password: password,
+		SSLMode: "prefer", ApplicationName: "pgschema-test-blocker",
+	})
+	require.NoError(t, err)
+	defer blockerConn.Close()
+
+	blockerTx, err := blockerConn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	_, err = blockerTx.ExecContext(ctx, `SELECT * FROM items`)
+	require.NoError(t, err, "should acquire a lock on items via the blocking transaction")
+	defer blockerTx.Rollback()
+
+	applyConfig := &ApplyConfig{
+		Host: host, Port: port, DB: dbname, User: user, Password: password,
+		Schema:          "public",
+		Plan:            migrationPlan,
+		AutoApprove:     true,
+		Quiet:           true,
+		LockTimeout:     "150ms",
+		RetryCount:      2,
+		RetryInterval:   150 * time.Millisecond,
+		ApplicationName: "pgschema",
+	}
+
+	err = ApplyMigration(applyConfig, nil)
+	require.Error(t, err, "apply should fail once retries are exhausted while the lock is still held")
+	assert.Contains(t, err.Error(), "lock", "error should mention the lock timeout")
+
+	var priceColumnExists bool
+	scanErr := conn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'items' AND column_name = 'price'
+		)
+	`).Scan(&priceColumnExists)
+	require.NoError(t, scanErr)
+	assert.False(t, priceColumnExists, "price column should not exist after the apply failed")
 }

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -101,6 +101,24 @@ func TestApplyCommand(t *testing.T) {
 		t.Errorf("Expected default lock-timeout to be empty, got '%s'", lockTimeoutFlag.DefValue)
 	}
 
+	// Test retry-count flag
+	retryCountFlag := flags.Lookup("retry-count")
+	if retryCountFlag == nil {
+		t.Error("Expected --retry-count flag to be defined")
+	}
+	if retryCountFlag.DefValue != "0" {
+		t.Errorf("Expected default retry-count to be '0', got '%s'", retryCountFlag.DefValue)
+	}
+
+	// Test retry-interval flag
+	retryIntervalFlag := flags.Lookup("retry-interval")
+	if retryIntervalFlag == nil {
+		t.Error("Expected --retry-interval flag to be defined")
+	}
+	if retryIntervalFlag.DefValue != "1s" {
+		t.Errorf("Expected default retry-interval to be '1s', got '%s'", retryIntervalFlag.DefValue)
+	}
+
 	// Test application-name flag
 	applicationNameFlag := flags.Lookup("application-name")
 	if applicationNameFlag == nil {
@@ -308,6 +326,96 @@ func TestApplyCommandFlagValidation(t *testing.T) {
 		// Should NOT be a flag validation error
 		if strings.Contains(err.Error(), "either --file or --plan must be specified") {
 			t.Errorf("Should not get flag validation error when --plan is specified: %v", err)
+		}
+	})
+}
+
+func TestApplyCommandRetryFlagValidation(t *testing.T) {
+	// Save original values
+	origDB := applyDB
+	origUser := applyUser
+	origFile := applyFile
+	origPlan := applyPlan
+	origLockTimeout := applyLockTimeout
+	origRetryCount := applyRetryCount
+	origRetryInterval := applyRetryInterval
+	defer func() {
+		applyDB = origDB
+		applyUser = origUser
+		applyFile = origFile
+		applyPlan = origPlan
+		applyLockTimeout = origLockTimeout
+		applyRetryCount = origRetryCount
+		applyRetryInterval = origRetryInterval
+	}()
+
+	// Use a plan file so validation is reached without requiring a database connection
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "plan.json")
+	planJSON := `{"version":"1.0.0","pgschema_version":"test","created_at":"2024-01-01T00:00:00Z","transaction":true,"summary":{"total":0,"add":0,"change":0,"destroy":0,"by_type":{}},"diffs":[]}`
+	if err := os.WriteFile(planPath, []byte(planJSON), 0644); err != nil {
+		t.Fatalf("Failed to write plan file: %v", err)
+	}
+
+	t.Run("negative retry-count is rejected", func(t *testing.T) {
+		applyDB = "testdb"
+		applyUser = "testuser"
+		applyFile = ""
+		applyPlan = planPath
+		applyLockTimeout = ""
+		applyRetryCount = -1
+		applyRetryInterval = "1s"
+
+		err := RunApply(ApplyCmd, []string{})
+		if err == nil || err.Error() != "--retry-count must be zero or positive" {
+			t.Errorf("Expected retry-count validation error, got: %v", err)
+		}
+	})
+
+	t.Run("retry-count without lock-timeout is rejected", func(t *testing.T) {
+		applyDB = "testdb"
+		applyUser = "testuser"
+		applyFile = ""
+		applyPlan = planPath
+		applyLockTimeout = ""
+		applyRetryCount = 3
+		applyRetryInterval = "1s"
+
+		err := RunApply(ApplyCmd, []string{})
+		if err == nil || err.Error() != "--retry-count requires --lock-timeout to be set" {
+			t.Errorf("Expected retry-count/lock-timeout validation error, got: %v", err)
+		}
+	})
+
+	t.Run("invalid retry-interval is rejected", func(t *testing.T) {
+		applyDB = "testdb"
+		applyUser = "testuser"
+		applyFile = ""
+		applyPlan = planPath
+		applyLockTimeout = "30s"
+		applyRetryCount = 3
+		applyRetryInterval = "not-a-duration"
+
+		err := RunApply(ApplyCmd, []string{})
+		if err == nil || !strings.Contains(err.Error(), "invalid --retry-interval") {
+			t.Errorf("Expected retry-interval validation error, got: %v", err)
+		}
+	})
+
+	t.Run("zero retry-count does not require lock-timeout", func(t *testing.T) {
+		applyDB = "testdb"
+		applyUser = "testuser"
+		applyFile = ""
+		applyPlan = planPath
+		applyLockTimeout = ""
+		applyRetryCount = 0
+		applyRetryInterval = "1s"
+
+		// Should pass retry validation and fail later (plan version mismatch),
+		// not on a retry-count/lock-timeout validation error.
+		err := RunApply(ApplyCmd, []string{})
+		if err != nil && strings.Contains(err.Error(), "retry-count") {
+			t.Errorf("Should not get retry-count validation error when retry-count is 0: %v", err)
 		}
 	})
 }
@@ -618,11 +726,11 @@ func TestApplyFileExtensionValidation(t *testing.T) {
 
 func TestValidateFileExtension(t *testing.T) {
 	tests := []struct {
-		name     string
-		file     string
-		plan     string
-		wantErr  bool
-		errMsg   string
+		name    string
+		file    string
+		plan    string
+		wantErr bool
+		errMsg  string
 	}{
 		{"file with json", "plan.json", "", true, "--file expects a SQL schema file"},
 		{"file with JSON uppercase", "plan.JSON", "", true, "--file expects a SQL schema file"},

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -101,22 +101,13 @@ func TestApplyCommand(t *testing.T) {
 		t.Errorf("Expected default lock-timeout to be empty, got '%s'", lockTimeoutFlag.DefValue)
 	}
 
-	// Test retry-count flag
-	retryCountFlag := flags.Lookup("retry-count")
-	if retryCountFlag == nil {
-		t.Error("Expected --retry-count flag to be defined")
+	// Retry flags are intentionally not exposed: lock timeout retries are
+	// automatic (exponential backoff) whenever --lock-timeout is set.
+	if flags.Lookup("retry-count") != nil {
+		t.Error("Expected --retry-count flag NOT to be defined; retries are automatic")
 	}
-	if retryCountFlag.DefValue != "0" {
-		t.Errorf("Expected default retry-count to be '0', got '%s'", retryCountFlag.DefValue)
-	}
-
-	// Test retry-interval flag
-	retryIntervalFlag := flags.Lookup("retry-interval")
-	if retryIntervalFlag == nil {
-		t.Error("Expected --retry-interval flag to be defined")
-	}
-	if retryIntervalFlag.DefValue != "1s" {
-		t.Errorf("Expected default retry-interval to be '1s', got '%s'", retryIntervalFlag.DefValue)
+	if flags.Lookup("retry-interval") != nil {
+		t.Error("Expected --retry-interval flag NOT to be defined; retries are automatic")
 	}
 
 	// Test application-name flag
@@ -326,126 +317,6 @@ func TestApplyCommandFlagValidation(t *testing.T) {
 		// Should NOT be a flag validation error
 		if strings.Contains(err.Error(), "either --file or --plan must be specified") {
 			t.Errorf("Should not get flag validation error when --plan is specified: %v", err)
-		}
-	})
-}
-
-func TestApplyCommandRetryFlagValidation(t *testing.T) {
-	// Save original values
-	origDB := applyDB
-	origUser := applyUser
-	origFile := applyFile
-	origPlan := applyPlan
-	origLockTimeout := applyLockTimeout
-	origRetryCount := applyRetryCount
-	origRetryInterval := applyRetryInterval
-	defer func() {
-		applyDB = origDB
-		applyUser = origUser
-		applyFile = origFile
-		applyPlan = origPlan
-		applyLockTimeout = origLockTimeout
-		applyRetryCount = origRetryCount
-		applyRetryInterval = origRetryInterval
-	}()
-
-	// Use a plan file so validation is reached without requiring a database connection
-	tmpDir := t.TempDir()
-	planPath := filepath.Join(tmpDir, "plan.json")
-	planJSON := `{"version":"1.0.0","pgschema_version":"test","created_at":"2024-01-01T00:00:00Z","transaction":true,"summary":{"total":0,"add":0,"change":0,"destroy":0,"by_type":{}},"diffs":[]}`
-	if err := os.WriteFile(planPath, []byte(planJSON), 0644); err != nil {
-		t.Fatalf("Failed to write plan file: %v", err)
-	}
-
-	t.Run("negative retry-count is rejected", func(t *testing.T) {
-		applyDB = "testdb"
-		applyUser = "testuser"
-		applyFile = ""
-		applyPlan = planPath
-		applyLockTimeout = ""
-		applyRetryCount = -1
-		applyRetryInterval = "1s"
-
-		err := RunApply(ApplyCmd, []string{})
-		if err == nil || err.Error() != "--retry-count must be zero or positive" {
-			t.Errorf("Expected retry-count validation error, got: %v", err)
-		}
-	})
-
-	t.Run("retry-count without lock-timeout is rejected", func(t *testing.T) {
-		applyDB = "testdb"
-		applyUser = "testuser"
-		applyFile = ""
-		applyPlan = planPath
-		applyLockTimeout = ""
-		applyRetryCount = 3
-		applyRetryInterval = "1s"
-
-		err := RunApply(ApplyCmd, []string{})
-		if err == nil || err.Error() != "--retry-count requires --lock-timeout to be set" {
-			t.Errorf("Expected retry-count/lock-timeout validation error, got: %v", err)
-		}
-	})
-
-	t.Run("invalid retry-interval is rejected", func(t *testing.T) {
-		applyDB = "testdb"
-		applyUser = "testuser"
-		applyFile = ""
-		applyPlan = planPath
-		applyLockTimeout = "30s"
-		applyRetryCount = 3
-		applyRetryInterval = "not-a-duration"
-
-		err := RunApply(ApplyCmd, []string{})
-		if err == nil || !strings.Contains(err.Error(), "invalid --retry-interval") {
-			t.Errorf("Expected retry-interval validation error, got: %v", err)
-		}
-	})
-
-	t.Run("zero retry-interval is rejected", func(t *testing.T) {
-		applyDB = "testdb"
-		applyUser = "testuser"
-		applyFile = ""
-		applyPlan = planPath
-		applyLockTimeout = "30s"
-		applyRetryCount = 3
-		applyRetryInterval = "0s"
-
-		err := RunApply(ApplyCmd, []string{})
-		if err == nil || err.Error() != "--retry-interval must be positive when --retry-count is set" {
-			t.Errorf("Expected retry-interval must be positive error, got: %v", err)
-		}
-	})
-
-	t.Run("negative retry-interval is rejected", func(t *testing.T) {
-		applyDB = "testdb"
-		applyUser = "testuser"
-		applyFile = ""
-		applyPlan = planPath
-		applyLockTimeout = "30s"
-		applyRetryCount = 3
-		applyRetryInterval = "-1s"
-
-		err := RunApply(ApplyCmd, []string{})
-		if err == nil || err.Error() != "--retry-interval must be positive when --retry-count is set" {
-			t.Errorf("Expected retry-interval must be positive error, got: %v", err)
-		}
-	})
-
-	t.Run("zero retry-count does not require lock-timeout", func(t *testing.T) {
-		applyDB = "testdb"
-		applyUser = "testuser"
-		applyFile = ""
-		applyPlan = planPath
-		applyLockTimeout = ""
-		applyRetryCount = 0
-		applyRetryInterval = "1s"
-
-		// Should pass retry validation and fail later (plan version mismatch),
-		// not on a retry-count/lock-timeout validation error.
-		err := RunApply(ApplyCmd, []string{})
-		if err != nil && strings.Contains(err.Error(), "retry-count") {
-			t.Errorf("Should not get retry-count validation error when retry-count is 0: %v", err)
 		}
 	})
 }

--- a/cmd/apply/apply_test.go
+++ b/cmd/apply/apply_test.go
@@ -402,6 +402,36 @@ func TestApplyCommandRetryFlagValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("zero retry-interval is rejected", func(t *testing.T) {
+		applyDB = "testdb"
+		applyUser = "testuser"
+		applyFile = ""
+		applyPlan = planPath
+		applyLockTimeout = "30s"
+		applyRetryCount = 3
+		applyRetryInterval = "0s"
+
+		err := RunApply(ApplyCmd, []string{})
+		if err == nil || err.Error() != "--retry-interval must be positive when --retry-count is set" {
+			t.Errorf("Expected retry-interval must be positive error, got: %v", err)
+		}
+	})
+
+	t.Run("negative retry-interval is rejected", func(t *testing.T) {
+		applyDB = "testdb"
+		applyUser = "testuser"
+		applyFile = ""
+		applyPlan = planPath
+		applyLockTimeout = "30s"
+		applyRetryCount = 3
+		applyRetryInterval = "-1s"
+
+		err := RunApply(ApplyCmd, []string{})
+		if err == nil || err.Error() != "--retry-interval must be positive when --retry-count is set" {
+			t.Errorf("Expected retry-interval must be positive error, got: %v", err)
+		}
+	})
+
 	t.Run("zero retry-count does not require lock-timeout", func(t *testing.T) {
 		applyDB = "testdb"
 		applyUser = "testuser"

--- a/docs/cli/apply.mdx
+++ b/docs/cli/apply.mdx
@@ -164,9 +164,9 @@ When using File Mode (`--file`), the apply command generates a plan internally u
   If not specified, uses PostgreSQL's default behavior (wait indefinitely). 
   See [PostgreSQL lock_timeout documentation](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT).
 
-  When set, a statement that fails to acquire a lock is automatically retried with
-  exponential backoff instead of failing immediately. `CREATE INDEX CONCURRENTLY` is
-  never retried.
+  When set, a group of statements executed together in an implicit transaction that fails to
+  acquire a lock is automatically retried with exponential backoff instead of failing immediately.
+  Statements executed outside a transaction (including `CREATE INDEX CONCURRENTLY`) are never retried.
 </ParamField>
 
 <ParamField path="--application-name" type="string" default="pgschema">

--- a/docs/cli/apply.mdx
+++ b/docs/cli/apply.mdx
@@ -165,6 +165,18 @@ When using File Mode (`--file`), the apply command generates a plan internally u
   See [PostgreSQL lock_timeout documentation](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT).
 </ParamField>
 
+<ParamField path="--retry-count" type="int" default="0">
+  Number of times to retry a statement that fails to acquire a lock within `--lock-timeout`
+
+  Requires `--lock-timeout` to be set. Combining a short lock timeout with retries lets a
+  migration back off and try again instead of queuing behind (and blocking) other queries
+  on a busy table. Defaults to `0`, which disables retries.
+</ParamField>
+
+<ParamField path="--retry-interval" type="string" default="1s">
+  Time to wait between retries after a lock timeout (e.g., '1s', '500ms')
+</ParamField>
+
 <ParamField path="--application-name" type="string" default="pgschema">
   Application name for database connection (visible in pg_stat_activity) (env: PGAPPNAME)
 
@@ -265,6 +277,26 @@ pgschema apply \
   --file schema.sql \
   --lock-timeout "30s"
 ```
+
+### With Lock Timeout and Retries
+
+```bash
+# Avoid blocking busy tables: wait at most 5s for a lock, retry up to 10 times
+pgschema apply \
+  --host localhost \
+  --db myapp \
+  --user postgres \
+  --file schema.sql \
+  --lock-timeout "5s" \
+  --retry-count 10 \
+  --retry-interval "2s"
+```
+
+This applies the zero-downtime migration pattern described in
+[Zero-downtime Postgres schema migrations, lock timeout and retries](https://postgres.ai/blog/20210923-zero-downtime-postgres-schema-migrations-lock-timeout-and-retries):
+a short `lock_timeout` prevents a DDL statement from queuing behind (and blocking) other
+queries, and retries give it repeated short chances to acquire the lock during a gap in
+traffic on the table.
 
 ### Custom Application Name
 

--- a/docs/cli/apply.mdx
+++ b/docs/cli/apply.mdx
@@ -166,11 +166,16 @@ When using File Mode (`--file`), the apply command generates a plan internally u
 </ParamField>
 
 <ParamField path="--retry-count" type="int" default="0">
-  Number of times to retry a statement that fails to acquire a lock within `--lock-timeout`
+  Number of times to retry a group of statements that fails to acquire a lock within `--lock-timeout`
 
   Requires `--lock-timeout` to be set. Combining a short lock timeout with retries lets a
   migration back off and try again instead of queuing behind (and blocking) other queries
   on a busy table. Defaults to `0`, which disables retries.
+
+  Retries apply only to statements that run together in an implicit transaction (so a
+  retry either applies the whole group or none of it). Statements executed individually
+  outside a transaction — such as `CREATE INDEX CONCURRENTLY`, which is not retried to
+  avoid masking a partially built index behind `IF NOT EXISTS` — are not retried.
 </ParamField>
 
 <ParamField path="--retry-interval" type="string" default="1s">

--- a/docs/cli/apply.mdx
+++ b/docs/cli/apply.mdx
@@ -163,23 +163,17 @@ When using File Mode (`--file`), the apply command generates a plan internally u
   
   If not specified, uses PostgreSQL's default behavior (wait indefinitely). 
   See [PostgreSQL lock_timeout documentation](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT).
-</ParamField>
 
-<ParamField path="--retry-count" type="int" default="0">
-  Number of times to retry a group of statements that fails to acquire a lock within `--lock-timeout`
-
-  Requires `--lock-timeout` to be set. Combining a short lock timeout with retries lets a
-  migration back off and try again instead of queuing behind (and blocking) other queries
-  on a busy table. Defaults to `0`, which disables retries.
+  When set, a group of statements that fails to acquire a lock within `--lock-timeout`
+  is automatically retried with exponential backoff, instead of queuing behind (and
+  blocking) other queries on a busy table. This is not configurable — there is no retry
+  count or interval flag — and combining a short lock timeout with automatic retries lets
+  a migration back off and try again on its own.
 
   Retries apply only to statements that run together in an implicit transaction (so a
   retry either applies the whole group or none of it). Statements executed individually
   outside a transaction — such as `CREATE INDEX CONCURRENTLY`, which is not retried to
   avoid masking a partially built index behind `IF NOT EXISTS` — are not retried.
-</ParamField>
-
-<ParamField path="--retry-interval" type="string" default="1s">
-  Time to wait between retries after a lock timeout (e.g., '1s', '500ms')
 </ParamField>
 
 <ParamField path="--application-name" type="string" default="pgschema">
@@ -283,25 +277,24 @@ pgschema apply \
   --lock-timeout "30s"
 ```
 
-### With Lock Timeout and Retries
+### With Lock Timeout and Automatic Retries
 
 ```bash
-# Avoid blocking busy tables: wait at most 5s for a lock, retry up to 10 times
+# Avoid blocking busy tables: wait at most 5s for a lock before backing off and retrying
 pgschema apply \
   --host localhost \
   --db myapp \
   --user postgres \
   --file schema.sql \
-  --lock-timeout "5s" \
-  --retry-count 10 \
-  --retry-interval "2s"
+  --lock-timeout "5s"
 ```
 
 This applies the zero-downtime migration pattern described in
 [Zero-downtime Postgres schema migrations, lock timeout and retries](https://postgres.ai/blog/20210923-zero-downtime-postgres-schema-migrations-lock-timeout-and-retries):
 a short `lock_timeout` prevents a DDL statement from queuing behind (and blocking) other
-queries, and retries give it repeated short chances to acquire the lock during a gap in
-traffic on the table.
+queries, and setting `--lock-timeout` automatically enables retries with exponential
+backoff, giving the statement repeated chances to acquire the lock during a gap in traffic
+on the table.
 
 ### Custom Application Name
 

--- a/docs/cli/apply.mdx
+++ b/docs/cli/apply.mdx
@@ -289,9 +289,7 @@ pgschema apply \
   --lock-timeout "5s"
 ```
 
-This applies the zero-downtime migration pattern described in
-[Zero-downtime Postgres schema migrations, lock timeout and retries](https://postgres.ai/blog/20210923-zero-downtime-postgres-schema-migrations-lock-timeout-and-retries):
-a short `lock_timeout` prevents a DDL statement from queuing behind (and blocking) other
+A short `lock_timeout` prevents a DDL statement from queuing behind (and blocking) other
 queries, and setting `--lock-timeout` automatically enables retries with exponential
 backoff, giving the statement repeated chances to acquire the lock during a gap in traffic
 on the table.

--- a/docs/cli/apply.mdx
+++ b/docs/cli/apply.mdx
@@ -164,16 +164,9 @@ When using File Mode (`--file`), the apply command generates a plan internally u
   If not specified, uses PostgreSQL's default behavior (wait indefinitely). 
   See [PostgreSQL lock_timeout documentation](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT).
 
-  When set, a group of statements that fails to acquire a lock within `--lock-timeout`
-  is automatically retried with exponential backoff, instead of queuing behind (and
-  blocking) other queries on a busy table. This is not configurable — there is no retry
-  count or interval flag — and combining a short lock timeout with automatic retries lets
-  a migration back off and try again on its own.
-
-  Retries apply only to statements that run together in an implicit transaction (so a
-  retry either applies the whole group or none of it). Statements executed individually
-  outside a transaction — such as `CREATE INDEX CONCURRENTLY`, which is not retried to
-  avoid masking a partially built index behind `IF NOT EXISTS` — are not retried.
+  When set, a statement that fails to acquire a lock is automatically retried with
+  exponential backoff instead of failing immediately. `CREATE INDEX CONCURRENTLY` is
+  never retried.
 </ParamField>
 
 <ParamField path="--application-name" type="string" default="pgschema">
@@ -268,7 +261,7 @@ pgschema apply \
 ### With Lock Timeout
 
 ```bash
-# Prevent blocking on long-running locks
+# Avoid blocking busy tables: wait at most 30s for a lock before backing off and retrying
 pgschema apply \
   --host localhost \
   --db myapp \
@@ -276,23 +269,6 @@ pgschema apply \
   --file schema.sql \
   --lock-timeout "30s"
 ```
-
-### With Lock Timeout and Automatic Retries
-
-```bash
-# Avoid blocking busy tables: wait at most 5s for a lock before backing off and retrying
-pgschema apply \
-  --host localhost \
-  --db myapp \
-  --user postgres \
-  --file schema.sql \
-  --lock-timeout "5s"
-```
-
-A short `lock_timeout` prevents a DDL statement from queuing behind (and blocking) other
-queries, and setting `--lock-timeout` automatically enables retries with exponential
-backoff, giving the statement repeated chances to acquire the lock during a gap in traffic
-on the table.
 
 ### Custom Application Name
 

--- a/docs/cli/apply.mdx
+++ b/docs/cli/apply.mdx
@@ -164,9 +164,8 @@ When using File Mode (`--file`), the apply command generates a plan internally u
   If not specified, uses PostgreSQL's default behavior (wait indefinitely). 
   See [PostgreSQL lock_timeout documentation](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT).
 
-  When set, a group of statements executed together in an implicit transaction that fails to
-  acquire a lock is automatically retried with exponential backoff instead of failing immediately.
-  Statements executed outside a transaction (including `CREATE INDEX CONCURRENTLY`) are never retried.
+  When set, a failed attempt to acquire a lock is automatically retried with exponential
+  backoff instead of failing immediately. `CREATE INDEX CONCURRENTLY` is never retried.
 </ParamField>
 
 <ParamField path="--application-name" type="string" default="pgschema">


### PR DESCRIPTION
## Summary

- When `--lock-timeout` is set on `pgschema apply`, a statement (or group of statements executed together in an implicit transaction) that fails to acquire a lock (PostgreSQL SQLSTATE `55P03`, `lock_not_available`) is now automatically retried with exponential backoff, instead of aborting the whole apply immediately.
- Retries are **not** user-configurable — there is no `--retry-count` / `--retry-interval` flag. The schedule is fixed internally: up to 3 attempts total, starting with a 1s backoff that doubles each retry, capped at 30s.
- Applies only to statements batched in an implicit transaction (safe to retry as a whole, since the batch either all applies or none does). Statements executed individually outside a transaction, and any group containing a `CONCURRENTLY` statement (e.g. `CREATE INDEX CONCURRENTLY`), are never retried — such statements build in multiple internal sub-transactions and can leave partial catalog state behind on failure, so retrying could silently skip over that partial state instead of surfacing it.

This implements the workflow requested in #557: pairing a short `lock_timeout` with automatic retries so DDL against busy tables doesn't queue behind (and block) other queries.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/apply/...` (full package, including integration tests):
  - `TestApplyCommand_LockTimeoutRetrySucceeds` — a statement blocked by a lock held in another session succeeds once the lock is released within the retry budget
  - `TestApplyCommand_LockTimeoutRetryExhausted` — the apply fails and applies nothing once retries are exhausted while the lock is still held
  - `TestApplyCommand_LockTimeoutRetryNotAppliedToConcurrentIndex` — `CREATE INDEX CONCURRENTLY` fails after a single lock-timeout attempt rather than retrying
  - All pre-existing `cmd/apply` tests continue to pass
- [x] Updated `docs/cli/apply.mdx` to describe the automatic retry behavior (no flags)

Closes #557