### PR TITLE
fix: preserve index NULLS FIRST / NULLS LAST ordering

### DIFF
--- a/internal/diff/index.go
+++ b/internal/diff/index.go
@@ -130,6 +130,12 @@ func generateIndexSQLWithNameMode(index *ir.Index, indexName string, targetSchem
 			builder.WriteString(" ")
 			builder.WriteString(col.Direction)
 		}
+
+		// Add null ordering if non-default
+		if col.NullOrder != "" {
+			builder.WriteString(" ")
+			builder.WriteString(col.NullOrder)
+		}
 	}
 	builder.WriteString(")")
 

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -1968,6 +1968,7 @@ func indexesStructurallyEqual(oldIndex, newIndex *ir.Index) bool {
 		if oldCol.Name != newCol.Name ||
 			oldCol.Position != newCol.Position ||
 			oldCol.Direction != newCol.Direction ||
+			oldCol.NullOrder != newCol.NullOrder ||
 			oldCol.Operator != newCol.Operator {
 			return false
 		}

--- a/internal/plan/rewrite.go
+++ b/internal/plan/rewrite.go
@@ -446,6 +446,9 @@ func generateIndexSQL(index *ir.Index, isConcurrent bool) string {
 		if col.Direction != "" && col.Direction != "ASC" {
 			part += " " + col.Direction
 		}
+		if col.NullOrder != "" {
+			part += " " + col.NullOrder
+		}
 		columnParts = append(columnParts, part)
 	}
 

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -831,6 +831,17 @@ func (i *Inspector) buildIndexes(ctx context.Context, schema *IR, targetSchema s
 				direction = indexRow.ColumnDirections[idx]
 			}
 
+			// Get null ordering from the ColumnNullOrderings array.
+			// Only store non-default orderings: ASC defaults to NULLS LAST,
+			// DESC defaults to NULLS FIRST.
+			nullOrder := ""
+			if idx < len(indexRow.ColumnNullOrderings) {
+				no := indexRow.ColumnNullOrderings[idx]
+				if (direction == "ASC" && no == "NULLS FIRST") || (direction == "DESC" && no == "NULLS LAST") {
+					nullOrder = no
+				}
+			}
+
 			// Get operator class from the ColumnOpclasses array
 			operatorClass := ""
 			if idx < len(indexRow.ColumnOpclasses) {
@@ -841,6 +852,7 @@ func (i *Inspector) buildIndexes(ctx context.Context, schema *IR, targetSchema s
 				Name:      columnName,
 				Position:  idx + 1,
 				Direction: direction,
+				NullOrder: nullOrder,
 				Operator:  operatorClass,
 			}
 

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -272,8 +272,9 @@ type Index struct {
 type IndexColumn struct {
 	Name      string `json:"name"`
 	Position  int    `json:"position"`
-	Direction string `json:"direction,omitempty"` // ASC, DESC
-	Operator  string `json:"operator,omitempty"`  // operator class
+	Direction string `json:"direction,omitempty"`   // ASC, DESC
+	NullOrder string `json:"null_order,omitempty"`  // NULLS FIRST, NULLS LAST (only when non-default)
+	Operator  string `json:"operator,omitempty"`    // operator class
 }
 
 // IndexType represents different types of database indexes

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -466,6 +466,14 @@ WITH index_base AS (
             FROM generate_series(1, idx.indnkeyatts) k
         ) as column_directions,
         ARRAY(
+            SELECT
+                CASE
+                    WHEN (idx.indoption[k-1] & 2) = 2 THEN 'NULLS FIRST'
+                    ELSE 'NULLS LAST'
+                END
+            FROM generate_series(1, idx.indnkeyatts) k
+        ) as column_null_orderings,
+        ARRAY(
             SELECT CASE
                 WHEN opc.opcdefault THEN ''  -- Omit default operator classes
                 ELSE COALESCE(opc.opcname, '')
@@ -513,6 +521,7 @@ SELECT
     ib.num_columns,
     ib.column_definitions,
     ib.column_directions,
+    ib.column_null_orderings,
     ib.column_opclasses,
     ib.include_columns
 FROM index_base ib

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -1983,6 +1983,14 @@ WITH index_base AS (
             FROM generate_series(1, idx.indnkeyatts) k
         ) as column_directions,
         ARRAY(
+            SELECT
+                CASE
+                    WHEN (idx.indoption[k-1] & 2) = 2 THEN 'NULLS FIRST'
+                    ELSE 'NULLS LAST'
+                END
+            FROM generate_series(1, idx.indnkeyatts) k
+        ) as column_null_orderings,
+        ARRAY(
             SELECT CASE
                 WHEN opc.opcdefault THEN ''  -- Omit default operator classes
                 ELSE COALESCE(opc.opcname, '')
@@ -2030,6 +2038,7 @@ SELECT
     ib.num_columns,
     ib.column_definitions,
     ib.column_directions,
+    ib.column_null_orderings,
     ib.column_opclasses,
     ib.include_columns
 FROM index_base ib
@@ -2059,10 +2068,11 @@ type GetIndexesForSchemaRow struct {
 	Reloptions        []string       `db:"reloptions" json:"reloptions"`
 	NumKeyColumns     int16          `db:"num_key_columns" json:"num_key_columns"`
 	NumColumns        int16          `db:"num_columns" json:"num_columns"`
-	ColumnDefinitions []string       `db:"column_definitions" json:"column_definitions"`
-	ColumnDirections  []string       `db:"column_directions" json:"column_directions"`
-	ColumnOpclasses   []string       `db:"column_opclasses" json:"column_opclasses"`
-	IncludeColumns    []string       `db:"include_columns" json:"include_columns"`
+	ColumnDefinitions  []string       `db:"column_definitions" json:"column_definitions"`
+	ColumnDirections   []string       `db:"column_directions" json:"column_directions"`
+	ColumnNullOrderings []string      `db:"column_null_orderings" json:"column_null_orderings"`
+	ColumnOpclasses    []string       `db:"column_opclasses" json:"column_opclasses"`
+	IncludeColumns     []string       `db:"include_columns" json:"include_columns"`
 }
 
 // GetIndexesForSchema retrieves all indexes for a specific schema
@@ -2095,6 +2105,7 @@ func (q *Queries) GetIndexesForSchema(ctx context.Context, dollar_1 sql.NullStri
 			&i.NumColumns,
 			pq.Array(&i.ColumnDefinitions),
 			pq.Array(&i.ColumnDirections),
+			pq.Array(&i.ColumnNullOrderings),
 			pq.Array(&i.ColumnOpclasses),
 			pq.Array(&i.IncludeColumns),
 		); err != nil {

--- a/testdata/diff/create_index/alter_index_null_order/diff.sql
+++ b/testdata/diff/create_index/alter_index_null_order/diff.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_events_desc;
+
+CREATE INDEX IF NOT EXISTS idx_events_desc ON events (occurred_at DESC NULLS LAST);

--- a/testdata/diff/create_index/alter_index_null_order/new.sql
+++ b/testdata/diff/create_index/alter_index_null_order/new.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS events (
+    id integer,
+    occurred_at timestamptz,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT events_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_desc ON events (occurred_at DESC NULLS LAST);

--- a/testdata/diff/create_index/alter_index_null_order/old.sql
+++ b/testdata/diff/create_index/alter_index_null_order/old.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public.events (
+    id INTEGER PRIMARY KEY,
+    occurred_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_events_desc ON public.events (occurred_at DESC);

--- a/testdata/diff/create_index/alter_index_null_order/plan.json
+++ b/testdata/diff/create_index/alter_index_null_order/plan.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.4",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "419bcc985216f91140775eb17086374b599df26b1580e015280a0d41f60f6487"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_desc_pgschema_new ON events (occurred_at DESC NULLS LAST);",
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.events.idx_events_desc"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "SELECT \n    COALESCE(i.indisvalid, false) as done,\n    CASE \n        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total\n        ELSE 0\n    END as progress\nFROM pg_class c\nLEFT JOIN pg_index i ON c.oid = i.indexrelid\nLEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid\nWHERE c.relname = 'idx_events_desc_pgschema_new';",
+          "directive": {
+            "type": "wait",
+            "message": "Creating index idx_events_desc_pgschema_new"
+          },
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.events.idx_events_desc"
+        }
+      ]
+    },
+    {
+      "steps": [
+        {
+          "sql": "DROP INDEX IF EXISTS idx_events_desc;",
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.events.idx_events_desc"
+        },
+        {
+          "sql": "ALTER INDEX idx_events_desc_pgschema_new RENAME TO idx_events_desc;",
+          "type": "table.index",
+          "operation": "alter",
+          "path": "public.events.idx_events_desc"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_index/alter_index_null_order/plan.sql
+++ b/testdata/diff/create_index/alter_index_null_order/plan.sql
@@ -1,0 +1,17 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_desc_pgschema_new ON events (occurred_at DESC NULLS LAST);
+
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_events_desc_pgschema_new';
+
+DROP INDEX IF EXISTS idx_events_desc;
+
+ALTER INDEX idx_events_desc_pgschema_new RENAME TO idx_events_desc;

--- a/testdata/diff/create_index/alter_index_null_order/plan.txt
+++ b/testdata/diff/create_index/alter_index_null_order/plan.txt
@@ -1,0 +1,32 @@
+Plan: 1 to modify.
+
+Summary by type:
+  tables: 1 to modify
+
+Tables:
+  ~ events
+    ~ idx_events_desc (index - concurrent rebuild)
+
+DDL to be executed:
+--------------------------------------------------
+
+-- Transaction Group #1
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_desc_pgschema_new ON events (occurred_at DESC NULLS LAST);
+
+-- Transaction Group #2
+-- pgschema:wait
+SELECT 
+    COALESCE(i.indisvalid, false) as done,
+    CASE 
+        WHEN p.blocks_total > 0 THEN p.blocks_done * 100 / p.blocks_total
+        ELSE 0
+    END as progress
+FROM pg_class c
+LEFT JOIN pg_index i ON c.oid = i.indexrelid
+LEFT JOIN pg_stat_progress_create_index p ON c.oid = p.index_relid
+WHERE c.relname = 'idx_events_desc_pgschema_new';
+
+-- Transaction Group #3
+DROP INDEX IF EXISTS idx_events_desc;
+
+ALTER INDEX idx_events_desc_pgschema_new RENAME TO idx_events_desc;


### PR DESCRIPTION
## Summary
- Index `NULLS FIRST` / `NULLS LAST` ordering was silently dropped by `dump` and ignored by `plan`, causing round-trip semantics to change (e.g. `DESC NULLS LAST` reloads as `DESC NULLS FIRST`)
- Fix touches all layers: IR struct (`NullOrder` field), SQL query (`indoption & 2`), inspector, both SQL emitters (diff + plan rewrite), and structural equality comparison
- Only non-default orderings are stored (ASC→NULLS LAST, DESC→NULLS FIRST), so existing indexes without explicit null ordering are unaffected

Fixes #561

## Test plan
- [x] New testdata case `alter_index_null_order`: old=`DESC`, new=`DESC NULLS LAST` → produces DROP+CREATE
- [x] Full test suite passes (`go test ./... -count=1 -short`)
- [x] `go build` and `go vet` clean
- [ ] @schema-codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)