### PR TITLE
chore: bump embedded PostgreSQL 18 to 18.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 The tool is written in Go 1.24.0 (toolchain go1.24.7) and uses:
 
 - Cobra for CLI commands
-- embedded-postgres v1.33.0 for plan command (temporary instances) and testing (no Docker required)
+- embedded-postgres v1.34.0 for plan command (temporary instances) and testing (no Docker required)
 - pgx/v5 v5.7.5 for database connections
 - BurntSushi/toml for TOML parsing (ignore config)
 - Supports PostgreSQL versions 14-18
@@ -138,7 +138,7 @@ PGAPPNAME=pgschema
 
 **Migration Planning**: The `diff` package compares IR representations to generate a sequence of migration steps with proper dependency ordering (topological sort).
 
-**Database Integration**: Uses `pgx/v5` for database connections and `embedded-postgres` (v1.33.0) for both the plan command (temporary instances) and integration testing (no Docker required).
+**Database Integration**: Uses `pgx/v5` for database connections and `embedded-postgres` (v1.34.0) for both the plan command (temporary instances) and integration testing (no Docker required).
 
 **Inspector-Only Approach**: Both desired state (from user SQL files) and current state (from target database) are obtained through database inspection. The plan command spins up an embedded PostgreSQL instance, applies user SQL files, then inspects it to get the desired state IR. This eliminates the need for SQL parsing and ensures consistency.
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.7
 
 require (
 	github.com/BurntSushi/toml v1.5.0
-	github.com/fergusstrange/embedded-postgres v1.33.0
+	github.com/fergusstrange/embedded-postgres v1.34.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fergusstrange/embedded-postgres v1.33.0 h1:ka8vmRpm4IDsES7NPXQ/NThAp1fc/f+crcXYjCW7wK0=
-github.com/fergusstrange/embedded-postgres v1.33.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
+github.com/fergusstrange/embedded-postgres v1.34.0 h1:c6RKhPKFsLVU+Tdxsx8q0UxCHsvZZ/iShAnljRBXs6s=
+github.com/fergusstrange/embedded-postgres v1.34.0/go.mod h1:w0YvnCgf19o6tskInrOOACtnqfVlOvluz3hlNLY7tRk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/testdata/dump/employee/pgschema.sql
+++ b/testdata/dump/employee/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.5.1
 
 

--- a/testdata/dump/issue_125_function_default/pgschema.sql
+++ b/testdata/dump/issue_125_function_default/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.5.1
 
 

--- a/testdata/dump/issue_191_function_procedure_overload/pgschema.sql
+++ b/testdata/dump/issue_191_function_procedure_overload/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.12.4
 
 

--- a/testdata/dump/issue_252_function_schema_qualifier/pgschema.sql
+++ b/testdata/dump/issue_252_function_schema_qualifier/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.7.0
 
 

--- a/testdata/dump/issue_275_truncated_function_grants/pgschema.sql
+++ b/testdata/dump/issue_275_truncated_function_grants/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.5.1
 
 

--- a/testdata/dump/issue_307_view_dependency_order/pgschema.sql
+++ b/testdata/dump/issue_307_view_dependency_order/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.7.2
 
 

--- a/testdata/dump/issue_320_plpgsql_reserved_keyword_type/pgschema.sql
+++ b/testdata/dump/issue_320_plpgsql_reserved_keyword_type/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.7.2
 
 

--- a/testdata/dump/issue_345_array_cast/pgschema.sql
+++ b/testdata/dump/issue_345_array_cast/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.7.3
 
 

--- a/testdata/dump/issue_396_check_constraint_is_not_null/pgschema.sql
+++ b/testdata/dump/issue_396_check_constraint_is_not_null/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.12.4
 
 

--- a/testdata/dump/issue_412_unique_nulls_not_distinct/pgschema.sql
+++ b/testdata/dump/issue_412_unique_nulls_not_distinct/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.12.4
 
 

--- a/testdata/dump/issue_420_varchar_array_length_modifier/pgschema.sql
+++ b/testdata/dump/issue_420_varchar_array_length_modifier/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.12.4
 
 

--- a/testdata/dump/issue_472_partition_clone_trigger/pgschema.sql
+++ b/testdata/dump/issue_472_partition_clone_trigger/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.12.4
 
 

--- a/testdata/dump/sakila/pgschema.sql
+++ b/testdata/dump/sakila/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.12.4
 
 

--- a/testdata/dump/tenant/pgschema.sql
+++ b/testdata/dump/tenant/pgschema.sql
@@ -2,7 +2,7 @@
 -- pgschema database dump
 --
 
--- Dumped from database version PostgreSQL 18.0
+-- Dumped from database version PostgreSQL 18.3
 -- Dumped by pgschema version 1.5.1
 
 


### PR DESCRIPTION
Upgrades `fergusstrange/embedded-postgres` v1.33.0 → v1.34.0. I diffed the two library releases: the **only** code change is the V18 binary pin moving from `18.0.0` to `18.3.0` — the V14–V17 pins are untouched, so older-version test runs are unaffected.

Also updated:
- `-- Dumped from database version PostgreSQL 18.0` → `18.3` in the dump fixture headers (cosmetic — the dump tests normalize these lines away, but the fixtures stay honest)
- The v1.33.0 references in `CLAUDE.md`

## Testing (all against the new 18.3.0 binaries)

- Full dump suite (`TestDumpCommand`, all 18 suites)
- Full `internal/diff` suite
- Full `internal/plan` suite
- `online/` integration tests (`TestPlanAndApply`), which exercise the PG18 native `NOT NULL ... NOT VALID` path from #566 on 18.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)