### PR TITLE
fix: order expression indexes after functions they reference

### DIFF
--- a/cmd/dump/dump_integration_test.go
+++ b/cmd/dump/dump_integration_test.go
@@ -187,6 +187,13 @@ func TestDumpCommand_Issue422QuotedCustomType(t *testing.T) {
 	runExactMatchTest(t, "issue_422_quoted_custom_type")
 }
 
+func TestDumpCommand_Issue569ExpressionIndexFunctionOrder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	runExactMatchTest(t, "issue_569_expression_index_function_order")
+}
+
 // Reproduces a bug where a column declared as `name` is dumped as `char[]`.
 // The inspector classifies any base type with pg_type.typelem <> 0 as an array,
 // but the `name` type has typelem = 18 (the OID of "char") despite not being an array.

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -566,7 +566,7 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 				if index.Schema == fromSchema {
 					index.Schema = toSchema
 				}
-				index.Where = replaceString(index.Where)
+				index.Where = stripQualifiers(replaceString(index.Where))
 				if index.IsExpression {
 					for _, col := range index.Columns {
 						col.Name = stripQualifiers(replaceString(col.Name))
@@ -603,7 +603,7 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 				if index.Schema == fromSchema {
 					index.Schema = toSchema
 				}
-				index.Where = replaceString(index.Where)
+				index.Where = stripQualifiers(replaceString(index.Where))
 				if index.IsExpression {
 					for _, col := range index.Columns {
 						col.Name = stripQualifiers(replaceString(col.Name))

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -604,6 +604,11 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 					index.Schema = toSchema
 				}
 				index.Where = replaceString(index.Where)
+				if index.IsExpression {
+					for _, col := range index.Columns {
+						col.Name = stripQualifiers(replaceString(col.Name))
+					}
+				}
 			}
 
 			// Normalize schema names in view triggers (e.g., INSTEAD OF triggers)

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -567,6 +567,11 @@ func normalizeSchemaNames(irData *ir.IR, fromSchema, toSchema string) {
 					index.Schema = toSchema
 				}
 				index.Where = replaceString(index.Where)
+				if index.IsExpression {
+					for _, col := range index.Columns {
+						col.Name = stripQualifiers(replaceString(col.Name))
+					}
+				}
 			}
 
 			// Normalize schema names in triggers

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -794,7 +794,7 @@ func newSameSchemaQualifierStripper(schema string) func(string) string {
 		return func(s string) string { return s }
 	}
 	prefix := schema + "."
-	funcPattern := regexp.MustCompile(regexp.QuoteMeta(prefix) + `([a-zA-Z_][a-zA-Z0-9_]*)\(`)
+	funcPattern := regexp.MustCompile(regexp.QuoteMeta(prefix) + `([a-zA-Z_][a-zA-Z0-9_$]*)\(`)
 	typePattern := regexp.MustCompile(`::` + regexp.QuoteMeta(prefix))
 	replaceQualifiers := func(s string) string {
 		s = funcPattern.ReplaceAllString(s, `${1}(`)

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2652,13 +2652,18 @@ func tableReferencesNewFunction(table *ir.Table, newFunctions map[string]struct{
 		}
 	}
 
-	// Check expression index columns
+	// Check expression index columns and partial index predicates
 	for _, index := range table.Indexes {
 		if index.IsExpression {
 			for _, col := range index.Columns {
 				if referencesNewFunction(col.Name, table.Schema, newFunctions) {
 					return true
 				}
+			}
+		}
+		if index.IsPartial && index.Where != "" {
+			if referencesNewFunction(index.Where, table.Schema, newFunctions) {
+				return true
 			}
 		}
 	}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2652,6 +2652,17 @@ func tableReferencesNewFunction(table *ir.Table, newFunctions map[string]struct{
 		}
 	}
 
+	// Check expression index columns
+	for _, index := range table.Indexes {
+		if index.IsExpression {
+			for _, col := range index.Columns {
+				if referencesNewFunction(col.Name, table.Schema, newFunctions) {
+					return true
+				}
+			}
+		}
+	}
+
 	return false
 }
 

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -788,6 +788,13 @@ func normalizeIndex(index *Index) {
 	if index.IsPartial && index.Where != "" {
 		index.Where = normalizeIndexWhereClause(index.Where)
 	}
+
+	// Strip same-schema qualifiers from expression index column names
+	if index.IsExpression && index.Schema != "" {
+		for _, col := range index.Columns {
+			col.Name = StripSchemaPrefixFromBody(col.Name, index.Schema)
+		}
+	}
 }
 
 // normalizeIndexWhereClause normalizes WHERE clauses in partial indexes

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -425,7 +425,7 @@ func StripSchemaPrefixFromBody(body, schema string) string {
 
 // isIdentChar returns true if the byte is a valid SQL identifier character.
 func isIdentChar(b byte) bool {
-	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '$'
 }
 
 // normalizeProcedure normalizes procedure representation

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -792,6 +792,9 @@ func normalizeIndex(index *Index) {
 	// Normalize WHERE clause for partial indexes
 	if index.IsPartial && index.Where != "" {
 		index.Where = normalizeIndexWhereClause(index.Where)
+		if index.Schema != "" {
+			index.Where = StripSchemaPrefixFromBody(index.Where, index.Schema)
+		}
 	}
 
 	// Strip same-schema qualifiers from expression index column names

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -287,6 +287,11 @@ func normalizeView(view *View) {
 	for _, trigger := range view.Triggers {
 		normalizeTrigger(trigger)
 	}
+
+	// Normalize indexes on materialized views
+	for _, index := range view.Indexes {
+		normalizeIndex(index)
+	}
 }
 
 // normalizeFunction normalizes function signature and definition

--- a/ir/normalize_test.go
+++ b/ir/normalize_test.go
@@ -89,6 +89,18 @@ func TestStripSchemaPrefixFromBody(t *testing.T) {
 			schema:   "public",
 			expected: "\nBEGIN\n    RETURN (SELECT count(*)::integer FROM users);\nEND;\n",
 		},
+		{
+			name:     "identifier with dollar sign",
+			body:     "public.user$1(full_name)",
+			schema:   "public",
+			expected: "user$1(full_name)",
+		},
+		{
+			name:     "dollar-quoted function name in expression",
+			body:     "(public.my_func$2(x) + public.other$fn(y))",
+			schema:   "public",
+			expected: "(my_func$2(x) + other$fn(y))",
+		},
 	}
 
 	for _, tt := range tests {

--- a/ir/quote.go
+++ b/ir/quote.go
@@ -153,7 +153,7 @@ func needsQuoting(identifier string) bool {
 		if i == 0 && !unicode.IsLetter(r) && r != '_' {
 			return true
 		}
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' {
 			return true
 		}
 	}

--- a/testdata/diff/dependency/index_expression_to_function/diff.sql
+++ b/testdata/diff/dependency/index_expression_to_function/diff.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION normalize_name(
+    text
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL,
+    full_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_normalized ON users (normalize_name(full_name));

--- a/testdata/diff/dependency/index_expression_to_function/new.sql
+++ b/testdata/diff/dependency/index_expression_to_function/new.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE FUNCTION public.normalize_name(text)
+RETURNS text AS $$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE TABLE public.users (
+    id serial PRIMARY KEY,
+    full_name text NOT NULL
+);
+
+CREATE INDEX idx_users_normalized ON public.users (normalize_name(full_name));

--- a/testdata/diff/dependency/index_expression_to_function/old.sql
+++ b/testdata/diff/dependency/index_expression_to_function/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no objects)

--- a/testdata/diff/dependency/index_expression_to_function/plan.json
+++ b/testdata/diff/dependency/index_expression_to_function/plan.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.5",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE OR REPLACE FUNCTION normalize_name(\n    text\n)\nRETURNS text\nLANGUAGE plpgsql\nIMMUTABLE\nAS $_$\nBEGIN\n    RETURN lower(trim($1));\nEND;\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.normalize_name"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS users (\n    id SERIAL,\n    full_name text NOT NULL,\n    CONSTRAINT users_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.users"
+        },
+        {
+          "sql": "CREATE INDEX IF NOT EXISTS idx_users_normalized ON users (normalize_name(full_name));",
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.users.idx_users_normalized"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/index_expression_to_function/plan.sql
+++ b/testdata/diff/dependency/index_expression_to_function/plan.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION normalize_name(
+    text
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL,
+    full_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_normalized ON users (normalize_name(full_name));

--- a/testdata/diff/dependency/index_expression_to_function/plan.txt
+++ b/testdata/diff/dependency/index_expression_to_function/plan.txt
@@ -1,0 +1,35 @@
+Plan: 2 to add.
+
+Summary by type:
+  functions: 1 to add
+  tables: 1 to add
+
+Functions:
+  + normalize_name
+
+Tables:
+  + users
+    + idx_users_normalized (index)
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE OR REPLACE FUNCTION normalize_name(
+    text
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL,
+    full_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_normalized ON users (normalize_name(full_name));

--- a/testdata/diff/dependency/matview_expression_index_to_function/diff.sql
+++ b/testdata/diff/dependency/matview_expression_index_to_function/diff.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL,
+    full_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION normalize_name(
+    text
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS user_directory AS
+ SELECT id,
+    full_name
+   FROM users;
+
+CREATE INDEX IF NOT EXISTS idx_user_dir_normalized ON user_directory (normalize_name(full_name));

--- a/testdata/diff/dependency/matview_expression_index_to_function/new.sql
+++ b/testdata/diff/dependency/matview_expression_index_to_function/new.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION public.normalize_name(text)
+RETURNS text AS $$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE TABLE public.users (
+    id serial PRIMARY KEY,
+    full_name text NOT NULL
+);
+
+CREATE MATERIALIZED VIEW public.user_directory AS
+SELECT id, full_name FROM public.users;
+
+CREATE INDEX idx_user_dir_normalized ON public.user_directory (normalize_name(full_name));

--- a/testdata/diff/dependency/matview_expression_index_to_function/old.sql
+++ b/testdata/diff/dependency/matview_expression_index_to_function/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no objects)

--- a/testdata/diff/dependency/matview_expression_index_to_function/plan.json
+++ b/testdata/diff/dependency/matview_expression_index_to_function/plan.json
@@ -1,0 +1,38 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.5",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS users (\n    id SERIAL,\n    full_name text NOT NULL,\n    CONSTRAINT users_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.users"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION normalize_name(\n    text\n)\nRETURNS text\nLANGUAGE plpgsql\nIMMUTABLE\nAS $_$\nBEGIN\n    RETURN lower(trim($1));\nEND;\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.normalize_name"
+        },
+        {
+          "sql": "CREATE MATERIALIZED VIEW IF NOT EXISTS user_directory AS\n SELECT id,\n    full_name\n   FROM users;",
+          "type": "materialized_view",
+          "operation": "create",
+          "path": "public.user_directory"
+        },
+        {
+          "sql": "CREATE INDEX IF NOT EXISTS idx_user_dir_normalized ON user_directory (normalize_name(full_name));",
+          "type": "materialized_view.index",
+          "operation": "create",
+          "path": "public.user_directory.idx_user_dir_normalized"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/matview_expression_index_to_function/plan.sql
+++ b/testdata/diff/dependency/matview_expression_index_to_function/plan.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL,
+    full_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION normalize_name(
+    text
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS user_directory AS
+ SELECT id,
+    full_name
+   FROM users;
+
+CREATE INDEX IF NOT EXISTS idx_user_dir_normalized ON user_directory (normalize_name(full_name));

--- a/testdata/diff/dependency/matview_expression_index_to_function/plan.txt
+++ b/testdata/diff/dependency/matview_expression_index_to_function/plan.txt
@@ -1,0 +1,44 @@
+Plan: 3 to add.
+
+Summary by type:
+  functions: 1 to add
+  tables: 1 to add
+  materialized views: 1 to add
+
+Functions:
+  + normalize_name
+
+Tables:
+  + users
+
+Materialized views:
+  + user_directory
+    + idx_user_dir_normalized (index)
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL,
+    full_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION normalize_name(
+    text
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS user_directory AS
+ SELECT id,
+    full_name
+   FROM users;
+
+CREATE INDEX IF NOT EXISTS idx_user_dir_normalized ON user_directory (normalize_name(full_name));

--- a/testdata/diff/dependency/partial_index_where_to_function/diff.sql
+++ b/testdata/diff/dependency/partial_index_where_to_function/diff.sql
@@ -18,4 +18,4 @@ CREATE TABLE IF NOT EXISTS accounts (
     CONSTRAINT accounts_pkey PRIMARY KEY (id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));
+CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (is_active(active, expires_at));

--- a/testdata/diff/dependency/partial_index_where_to_function/diff.sql
+++ b/testdata/diff/dependency/partial_index_where_to_function/diff.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION is_active(
+    boolean,
+    timestamp with time zone
+)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN $1 AND ($2 IS NULL OR $2 > now());
+END;
+$_$;
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id SERIAL,
+    active boolean DEFAULT true NOT NULL,
+    expires_at timestamptz,
+    CONSTRAINT accounts_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));

--- a/testdata/diff/dependency/partial_index_where_to_function/new.sql
+++ b/testdata/diff/dependency/partial_index_where_to_function/new.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE FUNCTION public.is_active(boolean, timestamptz)
+RETURNS boolean AS $$
+BEGIN
+    RETURN $1 AND ($2 IS NULL OR $2 > now());
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE TABLE public.accounts (
+    id serial PRIMARY KEY,
+    active boolean NOT NULL DEFAULT true,
+    expires_at timestamptz
+);
+
+CREATE INDEX idx_accounts_active ON public.accounts (id) WHERE is_active(active, expires_at);

--- a/testdata/diff/dependency/partial_index_where_to_function/old.sql
+++ b/testdata/diff/dependency/partial_index_where_to_function/old.sql
@@ -1,0 +1,1 @@
+-- Empty schema (no objects)

--- a/testdata/diff/dependency/partial_index_where_to_function/plan.json
+++ b/testdata/diff/dependency/partial_index_where_to_function/plan.json
@@ -21,7 +21,7 @@
           "path": "public.accounts"
         },
         {
-          "sql": "CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));",
+          "sql": "CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (is_active(active, expires_at));",
           "type": "table.index",
           "operation": "create",
           "path": "public.accounts.idx_accounts_active"

--- a/testdata/diff/dependency/partial_index_where_to_function/plan.json
+++ b/testdata/diff/dependency/partial_index_where_to_function/plan.json
@@ -1,0 +1,32 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.5",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE OR REPLACE FUNCTION is_active(\n    boolean,\n    timestamp with time zone\n)\nRETURNS boolean\nLANGUAGE plpgsql\nIMMUTABLE\nAS $_$\nBEGIN\n    RETURN $1 AND ($2 IS NULL OR $2 > now());\nEND;\n$_$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.is_active"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS accounts (\n    id SERIAL,\n    active boolean DEFAULT true NOT NULL,\n    expires_at timestamptz,\n    CONSTRAINT accounts_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.accounts"
+        },
+        {
+          "sql": "CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));",
+          "type": "table.index",
+          "operation": "create",
+          "path": "public.accounts.idx_accounts_active"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/partial_index_where_to_function/plan.sql
+++ b/testdata/diff/dependency/partial_index_where_to_function/plan.sql
@@ -18,4 +18,4 @@ CREATE TABLE IF NOT EXISTS accounts (
     CONSTRAINT accounts_pkey PRIMARY KEY (id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));
+CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (is_active(active, expires_at));

--- a/testdata/diff/dependency/partial_index_where_to_function/plan.sql
+++ b/testdata/diff/dependency/partial_index_where_to_function/plan.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE FUNCTION is_active(
+    boolean,
+    timestamp with time zone
+)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN $1 AND ($2 IS NULL OR $2 > now());
+END;
+$_$;
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id SERIAL,
+    active boolean DEFAULT true NOT NULL,
+    expires_at timestamptz,
+    CONSTRAINT accounts_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));

--- a/testdata/diff/dependency/partial_index_where_to_function/plan.txt
+++ b/testdata/diff/dependency/partial_index_where_to_function/plan.txt
@@ -34,4 +34,4 @@ CREATE TABLE IF NOT EXISTS accounts (
     CONSTRAINT accounts_pkey PRIMARY KEY (id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));
+CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (is_active(active, expires_at));

--- a/testdata/diff/dependency/partial_index_where_to_function/plan.txt
+++ b/testdata/diff/dependency/partial_index_where_to_function/plan.txt
@@ -1,0 +1,37 @@
+Plan: 2 to add.
+
+Summary by type:
+  functions: 1 to add
+  tables: 1 to add
+
+Functions:
+  + is_active
+
+Tables:
+  + accounts
+    + idx_accounts_active (index)
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE OR REPLACE FUNCTION is_active(
+    boolean,
+    timestamp with time zone
+)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN $1 AND ($2 IS NULL OR $2 > now());
+END;
+$_$;
+
+CREATE TABLE IF NOT EXISTS accounts (
+    id SERIAL,
+    active boolean DEFAULT true NOT NULL,
+    expires_at timestamptz,
+    CONSTRAINT accounts_pkey PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_active ON accounts (id) WHERE (public.is_active(active, expires_at));

--- a/testdata/diff/online/add_partial_index/diff.sql
+++ b/testdata/diff/online/add_partial_index/diff.sql
@@ -1,1 +1,1 @@
-CREATE INDEX IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::public.order_status, 'processing'::public.order_status, 'confirmed'::public.order_status)) AND (is_active IS NOT NULL);
+CREATE INDEX IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::order_status, 'processing'::order_status, 'confirmed'::order_status)) AND (is_active IS NOT NULL);

--- a/testdata/diff/online/add_partial_index/plan.json
+++ b/testdata/diff/online/add_partial_index/plan.json
@@ -9,7 +9,7 @@
     {
       "steps": [
         {
-          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::public.order_status, 'processing'::public.order_status, 'confirmed'::public.order_status)) AND (is_active IS NOT NULL);",
+          "sql": "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::order_status, 'processing'::order_status, 'confirmed'::order_status)) AND (is_active IS NOT NULL);",
           "type": "table.index",
           "operation": "create",
           "path": "public.orders.idx_active_orders_customer_date"

--- a/testdata/diff/online/add_partial_index/plan.sql
+++ b/testdata/diff/online/add_partial_index/plan.sql
@@ -1,4 +1,4 @@
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::public.order_status, 'processing'::public.order_status, 'confirmed'::public.order_status)) AND (is_active IS NOT NULL);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::order_status, 'processing'::order_status, 'confirmed'::order_status)) AND (is_active IS NOT NULL);
 
 -- pgschema:wait
 SELECT 

--- a/testdata/diff/online/add_partial_index/plan.txt
+++ b/testdata/diff/online/add_partial_index/plan.txt
@@ -11,7 +11,7 @@ DDL to be executed:
 --------------------------------------------------
 
 -- Transaction Group #1
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::public.order_status, 'processing'::public.order_status, 'confirmed'::public.order_status)) AND (is_active IS NOT NULL);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_active_orders_customer_date ON orders (customer_id, order_date DESC, total_amount) WHERE (status IN ('pending'::order_status, 'processing'::order_status, 'confirmed'::order_status)) AND (is_active IS NOT NULL);
 
 -- Transaction Group #2
 -- pgschema:wait

--- a/testdata/dump/issue_569_expression_index_function_order/manifest.json
+++ b/testdata/dump/issue_569_expression_index_function_order/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "issue_569_expression_index_function_order",
+  "description": "Test case for expression indexes being dumped after the functions they reference (GitHub issue #569)",
+  "source": "https://github.com/pgplex/pgschema/issues/569",
+  "notes": [
+    "Tests that expression indexes referencing user-defined functions are emitted after the functions",
+    "Without the fix, the table with its expression index would be dumped before the function"
+  ]
+}

--- a/testdata/dump/issue_569_expression_index_function_order/pgdump.sql
+++ b/testdata/dump/issue_569_expression_index_function_order/pgdump.sql
@@ -1,0 +1,57 @@
+--
+-- Name: normalize_name(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.normalize_name(text) RETURNS text
+    LANGUAGE plpgsql IMMUTABLE
+    AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    full_name text NOT NULL
+);
+
+--
+-- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.users_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+
+--
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+--
+-- Name: idx_users_normalized; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_users_normalized ON public.users USING btree (public.normalize_name(full_name));

--- a/testdata/dump/issue_569_expression_index_function_order/pgschema.sql
+++ b/testdata/dump/issue_569_expression_index_function_order/pgschema.sql
@@ -1,0 +1,40 @@
+--
+-- pgschema database dump
+--
+
+-- Dumped from database version PostgreSQL 18.3
+-- Dumped by pgschema version 1.12.5
+
+
+--
+-- Name: normalize_name(text); Type: FUNCTION; Schema: -; Owner: -
+--
+
+CREATE OR REPLACE FUNCTION normalize_name(
+    text
+)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+AS $_$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$_$;
+
+--
+-- Name: users; Type: TABLE; Schema: -; Owner: -
+--
+
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL,
+    full_name text NOT NULL,
+    CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+
+--
+-- Name: idx_users_normalized; Type: INDEX; Schema: -; Owner: -
+--
+
+CREATE INDEX IF NOT EXISTS idx_users_normalized ON users (normalize_name(full_name));
+

--- a/testdata/dump/issue_569_expression_index_function_order/raw.sql
+++ b/testdata/dump/issue_569_expression_index_function_order/raw.sql
@@ -1,0 +1,18 @@
+--
+-- Test case for GitHub issue #569: Expression indexes referencing user-defined
+-- functions must be dumped after the functions they depend on.
+--
+
+CREATE OR REPLACE FUNCTION public.normalize_name(text)
+RETURNS text AS $$
+BEGIN
+    RETURN lower(trim($1));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE TABLE public.users (
+    id serial PRIMARY KEY,
+    full_name text NOT NULL
+);
+
+CREATE INDEX idx_users_normalized ON public.users (normalize_name(full_name));


### PR DESCRIPTION
Fixes #569

## Summary

- `tableReferencesNewFunction()` now scans expression index columns for function references, ensuring tables with expression indexes like `CREATE INDEX ... ON t (normalize_name(col))` are placed in the "tables with function dependencies" bucket and emitted after `CREATE FUNCTION`.
- `normalizeIndex()` in the IR normalizer strips same-schema qualifiers from expression index column names (e.g., `public.func(col)` → `func(col)`), fixing idempotency for expression indexes with schema-qualified function references.
- `normalizeSchemaNames()` in the plan rewriter normalizes expression index column names when replacing temp schema references with the target schema.

## Test plan

- [x] Added diff test: `testdata/diff/dependency/index_expression_to_function/` — verifies function is emitted before table with expression index
- [x] Added plan integration test with fixtures (plan.sql, plan.json, plan.txt)
- [x] Verified diff test passes
- [x] Verified plan integration test passes (both generate and compare modes)
- [x] Full test suite passes (pre-existing goroutine leak in cmd package is unrelated)