### PR TITLE
fix: only collapse genuinely owned sequences into SERIAL (#573)

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1077,10 +1077,16 @@ func GenerateMigrationWithOptions(oldIR, newIR *ir.IR, targetSchema string, qual
 				}
 				continue
 			}
+			if seq.OwnedByTable != "" && seq.OwnedByColumn != "" && !columnExistsInTables(newTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
+				// Owner column is not part of the desired state (ignored table or
+				// a table in another schema): the sequence cannot be created with
+				// its OWNED BY, so leave it to whoever manages that table.
+				continue
+			}
 			diff.addedSequences = append(diff.addedSequences, seq)
 			// An explicitly created sequence can only be OWNED BY a column that
 			// already exists; if the column is created by this migration, apply
-			// the ownership after the tables (pg_dump orders it the same way).
+			// the ownership after all tables and columns are in place.
 			if seq.OwnedByTable != "" && seq.OwnedByColumn != "" && !columnExistsInTables(oldTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
 				diff.deferredSequenceOwners = append(diff.deferredSequenceOwners, seq)
 			}
@@ -1991,12 +1997,6 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 		generateSequenceComment(seq, targetSchema, DiffOperationCreate, collector)
 	}
 
-	// Attach OWNED BY for explicitly created sequences whose owning column was
-	// created above (the sequence itself was created before the tables).
-	for _, seq := range d.deferredSequenceOwners {
-		generateSequenceOwnedBySQL(seq, targetSchema, collector)
-	}
-
 	// Add deferred foreign key constraints from ALL batches AFTER all tables are created
 	// This ensures FK references to tables in any batch work correctly
 	allDeferredConstraints := append(append(deferredConstraints1, deferredConstraints2...), deferredConstraints3...)
@@ -2111,6 +2111,14 @@ func (d *ddlDiff) generateModifySQL(targetSchema string, collector *diffCollecto
 
 	// Modify tables
 	generateModifyTablesSQL(d.modifiedTables, d.droppedTables, d.fkPreDrops, targetSchema, collector)
+
+	// Attach OWNED BY for explicitly created sequences whose owning column was
+	// created by this migration, either with a new table (create phase) or by
+	// ALTER TABLE ... ADD COLUMN just above. The sequence itself was created
+	// before the tables so column defaults could reference it.
+	for _, seq := range d.deferredSequenceOwners {
+		generateSequenceOwnedBySQL(seq, targetSchema, collector)
+	}
 
 	// (Re)create the dependent foreign keys now that the replacement constraints exist
 	generateDeferredConstraintsSQL(d.fkPostAdds, targetSchema, collector)

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -290,6 +290,7 @@ type ddlDiff struct {
 	modifiedTypes             []*typeDiff
 	addedSequences            []*ir.Sequence
 	addedSerialSeqComments    []*ir.Sequence // SERIAL-owned sequences skipped from addedSequences but with comments to emit
+	deferredSequenceOwners    []*ir.Sequence // added sequences whose OWNED BY column is created in this migration; ownership is set after tables
 	droppedSequences          []*ir.Sequence
 	modifiedSequences         []*sequenceDiff
 	addedDefaultPrivileges    []*ir.DefaultPrivilege
@@ -503,6 +504,7 @@ func GenerateMigrationWithOptions(oldIR, newIR *ir.IR, targetSchema string, qual
 		modifiedTypes:              []*typeDiff{},
 		addedSequences:             []*ir.Sequence{},
 		addedSerialSeqComments:     []*ir.Sequence{},
+		deferredSequenceOwners:     []*ir.Sequence{},
 		droppedSequences:           []*ir.Sequence{},
 		modifiedSequences:          []*sequenceDiff{},
 		addedDefaultPrivileges:     []*ir.DefaultPrivilege{},
@@ -1064,10 +1066,10 @@ func GenerateMigrationWithOptions(oldIR, newIR *ir.IR, targetSchema string, qual
 	for _, key := range seqKeys {
 		seq := newSequences[key]
 		if _, exists := oldSequences[key]; !exists {
-			// Skip sequences owned by table columns only if the column is also new
-			// (created by SERIAL in CREATE TABLE). If the column already exists,
-			// we need to create the sequence explicitly for ALTER COLUMN to use.
-			if seq.OwnedByTable != "" && seq.OwnedByColumn != "" && !columnExistsInTables(oldTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
+			// Skip sequences created implicitly by a new SERIAL column
+			// (CREATE TABLE ... SERIAL). If the column already exists, we need
+			// to create the sequence explicitly for ALTER COLUMN to use.
+			if isSerialSequence(newTables, seq) && !columnExistsInTables(oldTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
 				// Sequence is created implicitly by CREATE TABLE (SERIAL). Emit its
 				// comment separately after all tables are created.
 				if seq.Comment != "" {
@@ -1076,6 +1078,12 @@ func GenerateMigrationWithOptions(oldIR, newIR *ir.IR, targetSchema string, qual
 				continue
 			}
 			diff.addedSequences = append(diff.addedSequences, seq)
+			// An explicitly created sequence can only be OWNED BY a column that
+			// already exists; if the column is created by this migration, apply
+			// the ownership after the tables (pg_dump orders it the same way).
+			if seq.OwnedByTable != "" && seq.OwnedByColumn != "" && !columnExistsInTables(oldTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
+				diff.deferredSequenceOwners = append(diff.deferredSequenceOwners, seq)
+			}
 		}
 	}
 
@@ -1084,8 +1092,8 @@ func GenerateMigrationWithOptions(oldIR, newIR *ir.IR, targetSchema string, qual
 	for _, key := range oldSeqKeys {
 		seq := oldSequences[key]
 		if _, exists := newSequences[key]; !exists {
-			// Skip sequences owned by table columns (created by SERIAL)
-			if seq.OwnedByTable != "" && seq.OwnedByColumn != "" && !columnExistsInTables(newTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
+			// Skip sequences dropped implicitly with their SERIAL column
+			if isSerialSequence(oldTables, seq) && !columnExistsInTables(newTables, seq.Schema, seq.OwnedByTable, seq.OwnedByColumn) {
 				continue
 			}
 			diff.droppedSequences = append(diff.droppedSequences, seq)
@@ -1096,11 +1104,9 @@ func GenerateMigrationWithOptions(oldIR, newIR *ir.IR, targetSchema string, qual
 	for _, key := range seqKeys {
 		newSeq := newSequences[key]
 		if oldSeq, exists := oldSequences[key]; exists {
-			// Skip sequences owned by table columns (created by SERIAL) for structural changes,
-			// but allow comment-only changes through so COMMENT ON SEQUENCE can be deployed.
-			isOwned := (oldSeq.OwnedByTable != "" && oldSeq.OwnedByColumn != "") ||
-				(newSeq.OwnedByTable != "" && newSeq.OwnedByColumn != "")
-			if isOwned {
+			// Skip SERIAL-backed sequences for structural changes, but allow
+			// comment-only changes through so COMMENT ON SEQUENCE can be deployed.
+			if isSerialSequence(oldTables, oldSeq) || isSerialSequence(newTables, newSeq) {
 				if oldSeq.Comment != newSeq.Comment {
 					diff.modifiedSequences = append(diff.modifiedSequences, &sequenceDiff{
 						Old: oldSeq,
@@ -1826,7 +1832,7 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	generateCreateTypesSQL(typesWithoutDeps, targetSchema, collector)
 
 	// Create sequences
-	generateCreateSequencesSQL(d.addedSequences, targetSchema, collector)
+	generateCreateSequencesSQL(d.addedSequences, d.deferredSequenceOwners, targetSchema, collector)
 
 	// Build map of existing tables (tables being modified, so they already exist)
 	existingTables := make(map[string]bool, len(d.modifiedTables))
@@ -1983,6 +1989,12 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// These were skipped from addedSequences but their comments must still be deployed.
 	for _, seq := range d.addedSerialSeqComments {
 		generateSequenceComment(seq, targetSchema, DiffOperationCreate, collector)
+	}
+
+	// Attach OWNED BY for explicitly created sequences whose owning column was
+	// created above (the sequence itself was created before the tables).
+	for _, seq := range d.deferredSequenceOwners {
+		generateSequenceOwnedBySQL(seq, targetSchema, collector)
 	}
 
 	// Add deferred foreign key constraints from ALL batches AFTER all tables are created
@@ -2409,6 +2421,25 @@ func sortedKeys[T any](m map[string]T) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// isSerialSequence reports whether seq is the implicit sequence behind a
+// SERIAL column in tables, i.e. it is created and dropped together with that
+// column rather than by explicit CREATE/DROP SEQUENCE statements.
+func isSerialSequence(tables map[string]*ir.Table, seq *ir.Sequence) bool {
+	if seq.OwnedByTable == "" || seq.OwnedByColumn == "" {
+		return false
+	}
+	table, exists := tables[seq.Schema+"."+seq.OwnedByTable]
+	if !exists {
+		return false
+	}
+	for _, col := range table.Columns {
+		if col.Name == seq.OwnedByColumn {
+			return col.IsSerial
+		}
+	}
+	return false
 }
 
 // columnExistsInTables checks if a column exists in the given tables map

--- a/internal/diff/identifier_quote_test.go
+++ b/internal/diff/identifier_quote_test.go
@@ -380,7 +380,7 @@ func TestGenerateSequenceSQL_OwnedByQuoting(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := generateSequenceSQL(tt.seq, tt.targetSchema, false)
+			got := generateSequenceSQL(tt.seq, tt.targetSchema, false, true)
 			if got != tt.want {
 				t.Errorf("generateSequenceSQL() = %q, want %q", got, tt.want)
 			}

--- a/internal/diff/qualify_schema_test.go
+++ b/internal/diff/qualify_schema_test.go
@@ -137,12 +137,12 @@ func TestQualifySchema_Sequence(t *testing.T) {
 		OwnedByColumn: "id",
 	}
 
-	def := generateSequenceSQL(seq, "public", false)
+	def := generateSequenceSQL(seq, "public", false, true)
 	if strings.Contains(def, "public.users_id_seq") || strings.Contains(def, "public.users") {
 		t.Errorf("default should not qualify the target schema: %q", def)
 	}
 
-	qualified := generateSequenceSQL(seq, "public", true)
+	qualified := generateSequenceSQL(seq, "public", true, true)
 	if !strings.Contains(qualified, "public.users_id_seq") {
 		t.Errorf("forced qualification should qualify the sequence name: %q", qualified)
 	}

--- a/internal/diff/sequence.go
+++ b/internal/diff/sequence.go
@@ -16,10 +16,16 @@ const (
 	integerMaxValue         int64 = math.MaxInt32 // integer max
 )
 
-// generateCreateSequencesSQL generates CREATE SEQUENCE statements
-func generateCreateSequencesSQL(sequences []*ir.Sequence, targetSchema string, collector *diffCollector) {
+// generateCreateSequencesSQL generates CREATE SEQUENCE statements. Sequences in
+// deferredOwners are created without their OWNED BY clause because the owning
+// column does not exist yet; see generateSequenceOwnedBySQL.
+func generateCreateSequencesSQL(sequences []*ir.Sequence, deferredOwners []*ir.Sequence, targetSchema string, collector *diffCollector) {
+	deferOwner := make(map[*ir.Sequence]bool, len(deferredOwners))
+	for _, seq := range deferredOwners {
+		deferOwner[seq] = true
+	}
 	for _, seq := range sequences {
-		sql := generateSequenceSQL(seq, targetSchema, collector.qualifySchema)
+		sql := generateSequenceSQL(seq, targetSchema, collector.qualifySchema, !deferOwner[seq])
 
 		// Create context for this statement
 		context := &diffContext{
@@ -37,6 +43,22 @@ func generateCreateSequencesSQL(sequences []*ir.Sequence, targetSchema string, c
 			generateSequenceComment(seq, targetSchema, DiffOperationCreate, collector)
 		}
 	}
+}
+
+// generateSequenceOwnedBySQL emits ALTER SEQUENCE ... OWNED BY for a sequence
+// created earlier without its owner (the owning column was created after it).
+func generateSequenceOwnedBySQL(seq *ir.Sequence, targetSchema string, collector *diffCollector) {
+	seqName := qualifyEntityNameMode(seq.Schema, seq.Name, targetSchema, collector.qualifySchema)
+	ownerTable := ir.QualifyEntityNameWithQuotesMode(seq.Schema, seq.OwnedByTable, targetSchema, collector.qualifySchema)
+	sql := fmt.Sprintf("ALTER SEQUENCE %s OWNED BY %s.%s;", seqName, ownerTable, ir.QuoteIdentifier(seq.OwnedByColumn))
+	context := &diffContext{
+		Type:                DiffTypeSequence,
+		Operation:           DiffOperationCreate,
+		Path:                fmt.Sprintf("%s.%s", seq.Schema, seq.Name),
+		Source:              seq,
+		CanRunInTransaction: true,
+	}
+	collector.collect(context, sql)
 }
 
 // generateSequenceComment emits a COMMENT ON SEQUENCE statement
@@ -103,8 +125,9 @@ func generateModifySequencesSQL(diffs []*sequenceDiff, targetSchema string, coll
 	}
 }
 
-// generateSequenceSQL generates CREATE SEQUENCE statement
-func generateSequenceSQL(seq *ir.Sequence, targetSchema string, qualifySchema bool) string {
+// generateSequenceSQL generates CREATE SEQUENCE statement. includeOwner controls
+// whether the OWNED BY clause is emitted inline.
+func generateSequenceSQL(seq *ir.Sequence, targetSchema string, qualifySchema bool, includeOwner bool) string {
 	var parts []string
 
 	seqName := qualifyEntityNameMode(seq.Schema, seq.Name, targetSchema, qualifySchema)
@@ -143,7 +166,7 @@ func generateSequenceSQL(seq *ir.Sequence, targetSchema string, qualifySchema bo
 	}
 
 	// Add sequence owner
-	if seq.OwnedByTable != "" && seq.OwnedByColumn != "" {
+	if includeOwner && seq.OwnedByTable != "" && seq.OwnedByColumn != "" {
 		ownerTable := ir.QualifyEntityNameWithQuotesMode(seq.Schema, seq.OwnedByTable, targetSchema, qualifySchema)
 		parts = append(parts, fmt.Sprintf("OWNED BY %s.%s", ownerTable, ir.QuoteIdentifier(seq.OwnedByColumn)))
 	}

--- a/internal/diff/table.go
+++ b/internal/diff/table.go
@@ -1864,20 +1864,12 @@ func buildColumnClauses(column *ir.Column, isPartOfAnyPK bool, tableSchema strin
 	return result
 }
 
-// isSerialColumn checks if a column is a SERIAL column (integer type with nextval default)
+// isSerialColumn reports whether a column was created with the SERIAL
+// shorthand. The IR flags this only when the default's sequence is owned by
+// the column and named <table>_<column>_seq; a column that references a
+// shared or custom-named sequence keeps its explicit DEFAULT (issue #573).
 func isSerialColumn(column *ir.Column) bool {
-	// Check if column has nextval default
-	if column.DefaultValue == nil || !strings.Contains(*column.DefaultValue, "nextval") {
-		return false
-	}
-
-	// Check if column is an integer type
-	switch column.DataType {
-	case "integer", "int4", "smallint", "int2", "bigint", "int8":
-		return true
-	default:
-		return false
-	}
+	return column.IsSerial
 }
 
 // formatColumnDataType formats a column's data type with appropriate modifiers for ALTER TABLE statements

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -402,6 +402,20 @@ func FromJSON(jsonData []byte) (*Plan, error) {
 
 // ========== PRIVATE METHODS ==========
 
+// sameChangeKey identifies create steps that together add one object: same
+// type and path, emitted from the same source object (e.g. CREATE SEQUENCE
+// plus a deferred ALTER SEQUENCE ... OWNED BY). Such steps are counted as a
+// single addition. Alter and drop steps, and steps without a source (plans
+// loaded from JSON), get no key and are counted individually as before.
+// Keying on the source keeps distinct objects that share a path, such as
+// overloaded functions, counted separately.
+func sameChangeKey(objType, path, operation string, source diff.DiffSource) string {
+	if source == nil || operation != "create" {
+		return ""
+	}
+	return fmt.Sprintf("%s.%s.%s.%p", objType, path, operation, source)
+}
+
 // calculateSummaryFromSteps calculates summary statistics from the plan diffs
 func (p *Plan) calculateSummaryFromSteps() PlanSummary {
 	summary := PlanSummary{
@@ -437,8 +451,11 @@ func (p *Plan) calculateSummaryFromSteps() PlanSummary {
 	// These should be counted as modifications, not adds
 	materializedViewsRecreating := make(map[string]bool) // materialized_view_path -> true
 
-	// Track non-table/non-view/non-materialized-view operations
+	// Track non-table/non-view/non-materialized-view operations. A single
+	// object change may span several steps (e.g. CREATE SEQUENCE plus a
+	// deferred ALTER SEQUENCE ... OWNED BY); count those once.
 	nonTableOperations := make(map[string][]string) // objType -> []operations
+	seenNonTableOperations := make(map[string]bool) // sameChangeKey -> true
 
 	// Use source diffs for summary calculation if available,
 	// otherwise use steps metadata (for plans loaded from JSON)
@@ -446,19 +463,22 @@ func (p *Plan) calculateSummaryFromSteps() PlanSummary {
 		Type      string
 		Operation string
 		Path      string
+		Source    diff.DiffSource
 	}
 
 	if len(p.SourceDiffs) > 0 {
 		// Use SourceDiffs (for freshly generated plans)
-		for _, diff := range p.SourceDiffs {
+		for _, srcDiff := range p.SourceDiffs {
 			dataToProcess = append(dataToProcess, struct {
 				Type      string
 				Operation string
 				Path      string
+				Source    diff.DiffSource
 			}{
-				Type:      diff.Type.String(),
-				Operation: diff.Operation.String(),
-				Path:      diff.Path,
+				Type:      srcDiff.Type.String(),
+				Operation: srcDiff.Operation.String(),
+				Path:      srcDiff.Path,
+				Source:    srcDiff.Source,
 			})
 		}
 	} else {
@@ -470,6 +490,7 @@ func (p *Plan) calculateSummaryFromSteps() PlanSummary {
 						Type      string
 						Operation string
 						Path      string
+						Source    diff.DiffSource
 					}{
 						Type:      step.Type,
 						Operation: step.Operation,
@@ -523,7 +544,14 @@ func (p *Plan) calculateSummaryFromSteps() PlanSummary {
 				}
 			}
 		} else {
-			// For non-table/non-view objects, track each operation
+			// For non-table/non-view objects, track each operation once per source object
+			key := sameChangeKey(stepObjTypeStr, step.Path, step.Operation, step.Source)
+			if key != "" && seenNonTableOperations[key] {
+				continue
+			}
+			if key != "" {
+				seenNonTableOperations[key] = true
+			}
 			nonTableOperations[stepObjTypeStr] = append(nonTableOperations[stepObjTypeStr], step.Operation)
 		}
 	}
@@ -1087,6 +1115,9 @@ func (p *Plan) writeNonTableChanges(summary *strings.Builder, objType string, c 
 		path      string
 	}
 
+	// List a change once even when it spans several steps for the same object
+	seen := make(map[string]bool)
+
 	// Use source diffs for summary calculation
 	for _, step := range p.SourceDiffs {
 		// Normalize object type
@@ -1098,6 +1129,13 @@ func (p *Plan) writeNonTableChanges(summary *strings.Builder, objType string, c 
 		stepObjTypeStr = strings.ReplaceAll(stepObjTypeStr, "_", " ")
 
 		if stepObjTypeStr == objType {
+			key := sameChangeKey(stepObjTypeStr, step.Path, step.Operation.String(), step.Source)
+			if key != "" && seen[key] {
+				continue
+			}
+			if key != "" {
+				seen[key] = true
+			}
 			changes = append(changes, struct {
 				operation string
 				path      string

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -972,6 +972,11 @@ func (i *Inspector) buildSequences(ctx context.Context, schema *IR, targetSchema
 			sequence.OwnedByColumn = seq.OwnedByColumn.String
 		}
 
+		// Skip sequences owned by an ignored table; they live and die with it
+		if i.ignoreConfig != nil && sequence.OwnedByTable != "" && i.ignoreConfig.ShouldIgnoreTable(sequence.OwnedByTable) {
+			continue
+		}
+
 		// Skip sequences that are owned by identity columns
 		// Identity sequences should be managed through the identity column, not as separate sequences
 		if sequence.OwnedByTable != "" && sequence.OwnedByColumn != "" {

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -92,6 +92,13 @@ type Column struct {
 	GeneratedExpr *string   `json:"generated_expr,omitempty"` // Expression for generated columns
 	IsGenerated   bool      `json:"is_generated,omitempty"`   // True if this is a generated column
 	GeneratedKind string    `json:"generated_kind,omitempty"` // "s" for STORED, "v" for VIRTUAL (PG18+)
+	// IsSerial is true when the column was created with the SERIAL shorthand:
+	// its default is nextval() on a sequence that is owned by this column
+	// (pg_depend) and that carries PostgreSQL's default <table>_<column>_seq
+	// name. Only such columns may be rendered back as SERIAL; a column that
+	// merely references a shared or custom-named sequence keeps its explicit
+	// DEFAULT (issue #573). Derived during normalization, not serialized.
+	IsSerial bool `json:"-"`
 }
 
 // Identity represents PostgreSQL identity column configuration

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -38,6 +38,9 @@ func normalizeSchema(schema *Schema) {
 		normalizeTable(table)
 	}
 
+	// Mark SERIAL columns once column defaults and sequences are normalized
+	markSerialColumns(schema)
+
 	// Normalize views
 	for _, view := range schema.Views {
 		normalizeView(view)
@@ -69,6 +72,83 @@ func normalizeSchema(schema *Schema) {
 			revoked.ObjectName = normalizePrivilegeObjectName(revoked.ObjectName, schema.Name)
 		}
 	}
+}
+
+// markSerialColumns flags columns that PostgreSQL would have created via the
+// SERIAL shorthand. A column qualifies only when its default is nextval() on a
+// sequence that is owned by the column (pg_depend deptype 'a') and whose name
+// is the one CREATE TABLE ... SERIAL would pick (<table>_<column>_seq,
+// truncated to NAMEDATALEN-1). Anything else, such as a shared sequence used by
+// several tables or a custom-named owned sequence, must keep its explicit
+// DEFAULT and explicit CREATE SEQUENCE (issue #573).
+func markSerialColumns(schema *Schema) {
+	for _, seq := range schema.Sequences {
+		if seq.OwnedByTable == "" || seq.OwnedByColumn == "" {
+			continue
+		}
+		table, ok := schema.Tables[seq.OwnedByTable]
+		if !ok {
+			continue
+		}
+		var column *Column
+		for _, col := range table.Columns {
+			if col.Name == seq.OwnedByColumn {
+				column = col
+				break
+			}
+		}
+		if column == nil || column.DefaultValue == nil || column.Identity != nil {
+			continue
+		}
+		switch column.DataType {
+		case "integer", "int4", "smallint", "int2", "bigint", "int8":
+		default:
+			continue
+		}
+		if seq.Name != serialSequenceName(table.Name, column.Name) {
+			continue
+		}
+		if nextvalSequenceName(*column.DefaultValue) != seq.Name {
+			continue
+		}
+		column.IsSerial = true
+	}
+}
+
+// nextvalRegexp matches a normalized nextval() default and captures the
+// sequence name, optionally schema-qualified and/or double-quoted.
+var nextvalRegexp = regexp.MustCompile(`^nextval\('(?:"(?:[^"]|"")*"\.|[^.'"]+\.)?("(?:[^"]|"")*"|[^'".]+)'::regclass\)$`)
+
+// nextvalSequenceName returns the sequence referenced by a nextval() default,
+// or "" if the default is not a plain nextval() call.
+func nextvalSequenceName(defaultValue string) string {
+	m := nextvalRegexp.FindStringSubmatch(strings.TrimSpace(defaultValue))
+	if m == nil {
+		return ""
+	}
+	name := m[1]
+	if strings.HasPrefix(name, "\"") {
+		name = strings.ReplaceAll(name[1:len(name)-1], "\"\"", "\"")
+	}
+	return name
+}
+
+// serialSequenceName mirrors PostgreSQL's makeObjectName(table, column, "seq"):
+// when the combined name exceeds NAMEDATALEN-1 bytes, the longer of the two
+// parts is trimmed first, one byte at a time, until it fits.
+func serialSequenceName(tableName, columnName string) string {
+	const maxNameLen = 63
+	name1 := []byte(tableName)
+	name2 := []byte(columnName)
+	overhead := len("seq") + 2 // two underscores
+	for len(name1)+len(name2)+overhead > maxNameLen {
+		if len(name1) > len(name2) {
+			name1 = name1[:len(name1)-1]
+		} else {
+			name2 = name2[:len(name2)-1]
+		}
+	}
+	return string(name1) + "_" + string(name2) + "_seq"
 }
 
 // normalizeTable normalizes table-related objects

--- a/ir/normalize_test.go
+++ b/ir/normalize_test.go
@@ -1,6 +1,7 @@
 package ir
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -593,5 +594,78 @@ func TestStripRedundantTextCast(t *testing.T) {
 				t.Errorf("stripRedundantTextCast(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestSerialSequenceName(t *testing.T) {
+	long := strings.Repeat("t", 40)
+	tests := []struct {
+		table, column, want string
+	}{
+		{"users", "id", "users_id_seq"},
+		// Longer part is trimmed first until the name fits in 63 bytes
+		{long, strings.Repeat("c", 30), strings.Repeat("t", 29) + "_" + strings.Repeat("c", 29) + "_seq"},
+		{long, "id", strings.Repeat("t", 40) + "_id_seq"},
+	}
+	for _, tt := range tests {
+		if got := serialSequenceName(tt.table, tt.column); got != tt.want {
+			t.Errorf("serialSequenceName(%q, %q) = %q, want %q", tt.table, tt.column, got, tt.want)
+		}
+		if len(serialSequenceName(tt.table, tt.column)) > 63 {
+			t.Errorf("serialSequenceName(%q, %q) exceeds 63 bytes", tt.table, tt.column)
+		}
+	}
+}
+
+func TestNextvalSequenceName(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"nextval('users_id_seq'::regclass)", "users_id_seq"},
+		{"nextval('public.users_id_seq'::regclass)", "users_id_seq"},
+		{`nextval('"MySeq"'::regclass)`, "MySeq"},
+		{`nextval('"my schema"."My""Seq"'::regclass)`, `My"Seq`},
+		{"nextval('shared_seq'::regclass) + 1", ""},
+		{"42", ""},
+	}
+	for _, tt := range tests {
+		if got := nextvalSequenceName(tt.in); got != tt.want {
+			t.Errorf("nextvalSequenceName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestMarkSerialColumns(t *testing.T) {
+	def := func(s string) *string { return &s }
+	col := func(name, typ, defVal string) *Column {
+		return &Column{Name: name, DataType: typ, DefaultValue: def(defVal)}
+	}
+	schema := &Schema{
+		Name: "public",
+		Tables: map[string]*Table{
+			"users":  {Name: "users", Columns: []*Column{col("id", "integer", "nextval('users_id_seq'::regclass)")}},
+			"orders": {Name: "orders", Columns: []*Column{col("id", "integer", "nextval('shared_seq'::regclass)")}},
+			"widget": {Name: "widget", Columns: []*Column{col("id", "integer", "nextval('widget_custom_seq'::regclass)")}},
+			"notes":  {Name: "notes", Columns: []*Column{col("id", "text", "nextval('notes_id_seq'::regclass)")}},
+		},
+		Sequences: map[string]*Sequence{
+			"users_id_seq":      {Name: "users_id_seq", OwnedByTable: "users", OwnedByColumn: "id"},
+			"shared_seq":        {Name: "shared_seq"},
+			"widget_custom_seq": {Name: "widget_custom_seq", OwnedByTable: "widget", OwnedByColumn: "id"},
+			"notes_id_seq":      {Name: "notes_id_seq", OwnedByTable: "notes", OwnedByColumn: "id"},
+		},
+	}
+	markSerialColumns(schema)
+
+	want := map[string]bool{
+		"users":  true,  // owned + default name + nextval default
+		"orders": false, // shared, unowned sequence (issue #573)
+		"widget": false, // owned but custom-named
+		"notes":  false, // non-integer column
+	}
+	for table, wantSerial := range want {
+		if got := schema.Tables[table].Columns[0].IsSerial; got != wantSerial {
+			t.Errorf("%s.id IsSerial = %v, want %v", table, got, wantSerial)
+		}
 	}
 }

--- a/ir/queries/queries.sql
+++ b/ir/queries/queries.sql
@@ -1093,35 +1093,18 @@ SELECT
     s.increment_by AS increment,
     s.cycle AS cycle_option,
     s.cache_size,
-    COALESCE(dep_table.relname, col_table.table_name) AS owned_by_table,
-    COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column,
+    COALESCE(dep_table.relname, '') AS owned_by_table,
+    COALESCE(dep_col.attname, '') AS owned_by_column,
     COALESCE(obj_description(c.oid, 'pg_class'), '') AS sequence_comment
 FROM pg_sequences s
 LEFT JOIN pg_namespace n ON n.nspname = s.schemaname
 LEFT JOIN pg_class c ON c.relname = s.sequencename AND c.relnamespace = n.oid
--- Method 1: Try to find dependency relationship (for proper SERIAL columns)
+-- Ownership comes only from pg_depend (SERIAL / OWNED BY / identity). A
+-- sequence merely referenced by a column DEFAULT nextval() is not owned by
+-- that column and must be dumped and created explicitly (issue #573).
 LEFT JOIN pg_depend d ON d.objid = c.oid AND d.classid = 'pg_class'::regclass AND d.deptype IN ('a', 'i')
 LEFT JOIN pg_class dep_table ON d.refobjid = dep_table.oid
 LEFT JOIN pg_attribute dep_col ON dep_col.attrelid = dep_table.oid AND dep_col.attnum = d.refobjsubid
--- Method 2: Find sequences used in column defaults (for nextval() patterns)
-LEFT JOIN (
-    SELECT
-        col.table_name,
-        col.column_name,
-        REPLACE(
-            REGEXP_REPLACE(
-                REGEXP_REPLACE(
-                    REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-                    '^("([^"]|"")*"\.|[^.]*\.)', ''
-                ),
-                '^"(.*)"$', '\1'
-            ),
-            '""', '"'
-        ) AS sequence_name
-    FROM information_schema.columns col
-    WHERE col.table_schema = $1
-      AND col.column_default LIKE '%nextval%'
-) col_table ON col_table.sequence_name = s.sequencename
 WHERE s.schemaname = $1
 ORDER BY s.schemaname, s.sequencename;
 

--- a/ir/queries/queries.sql.go
+++ b/ir/queries/queries.sql.go
@@ -2054,25 +2054,25 @@ ORDER BY ib.schemaname, ib.tablename, ib.indexname
 `
 
 type GetIndexesForSchemaRow struct {
-	Schemaname        string         `db:"schemaname" json:"schemaname"`
-	Tablename         string         `db:"tablename" json:"tablename"`
-	Indexname         string         `db:"indexname" json:"indexname"`
-	IsUnique          bool           `db:"is_unique" json:"is_unique"`
-	IsPrimary         bool           `db:"is_primary" json:"is_primary"`
-	IsPartial         sql.NullBool   `db:"is_partial" json:"is_partial"`
-	Method            string         `db:"method" json:"method"`
-	Indexdef          sql.NullString `db:"indexdef" json:"indexdef"`
-	PartialPredicate  sql.NullString `db:"partial_predicate" json:"partial_predicate"`
-	HasExpressions    sql.NullBool   `db:"has_expressions" json:"has_expressions"`
-	IndexComment      sql.NullString `db:"index_comment" json:"index_comment"`
-	Reloptions        []string       `db:"reloptions" json:"reloptions"`
-	NumKeyColumns     int16          `db:"num_key_columns" json:"num_key_columns"`
-	NumColumns        int16          `db:"num_columns" json:"num_columns"`
-	ColumnDefinitions  []string       `db:"column_definitions" json:"column_definitions"`
-	ColumnDirections   []string       `db:"column_directions" json:"column_directions"`
-	ColumnNullOrderings []string      `db:"column_null_orderings" json:"column_null_orderings"`
-	ColumnOpclasses    []string       `db:"column_opclasses" json:"column_opclasses"`
-	IncludeColumns     []string       `db:"include_columns" json:"include_columns"`
+	Schemaname          string         `db:"schemaname" json:"schemaname"`
+	Tablename           string         `db:"tablename" json:"tablename"`
+	Indexname           string         `db:"indexname" json:"indexname"`
+	IsUnique            bool           `db:"is_unique" json:"is_unique"`
+	IsPrimary           bool           `db:"is_primary" json:"is_primary"`
+	IsPartial           sql.NullBool   `db:"is_partial" json:"is_partial"`
+	Method              string         `db:"method" json:"method"`
+	Indexdef            sql.NullString `db:"indexdef" json:"indexdef"`
+	PartialPredicate    sql.NullString `db:"partial_predicate" json:"partial_predicate"`
+	HasExpressions      sql.NullBool   `db:"has_expressions" json:"has_expressions"`
+	IndexComment        sql.NullString `db:"index_comment" json:"index_comment"`
+	Reloptions          []string       `db:"reloptions" json:"reloptions"`
+	NumKeyColumns       int16          `db:"num_key_columns" json:"num_key_columns"`
+	NumColumns          int16          `db:"num_columns" json:"num_columns"`
+	ColumnDefinitions   []string       `db:"column_definitions" json:"column_definitions"`
+	ColumnDirections    []string       `db:"column_directions" json:"column_directions"`
+	ColumnNullOrderings []string       `db:"column_null_orderings" json:"column_null_orderings"`
+	ColumnOpclasses     []string       `db:"column_opclasses" json:"column_opclasses"`
+	IncludeColumns      []string       `db:"include_columns" json:"include_columns"`
 }
 
 // GetIndexesForSchema retrieves all indexes for a specific schema
@@ -2994,8 +2994,8 @@ SELECT
     s.increment_by AS increment,
     s.cycle AS cycle_option,
     s.cache_size,
-    COALESCE(dep_table.relname, col_table.table_name) AS owned_by_table,
-    COALESCE(dep_col.attname, col_table.column_name) AS owned_by_column,
+    COALESCE(dep_table.relname, '') AS owned_by_table,
+    COALESCE(dep_col.attname, '') AS owned_by_column,
     COALESCE(obj_description(c.oid, 'pg_class'), '') AS sequence_comment
 FROM pg_sequences s
 LEFT JOIN pg_namespace n ON n.nspname = s.schemaname
@@ -3003,24 +3003,6 @@ LEFT JOIN pg_class c ON c.relname = s.sequencename AND c.relnamespace = n.oid
 LEFT JOIN pg_depend d ON d.objid = c.oid AND d.classid = 'pg_class'::regclass AND d.deptype IN ('a', 'i')
 LEFT JOIN pg_class dep_table ON d.refobjid = dep_table.oid
 LEFT JOIN pg_attribute dep_col ON dep_col.attrelid = dep_table.oid AND dep_col.attnum = d.refobjsubid
-LEFT JOIN (
-    SELECT
-        col.table_name,
-        col.column_name,
-        REPLACE(
-            REGEXP_REPLACE(
-                REGEXP_REPLACE(
-                    REGEXP_REPLACE(col.column_default, 'nextval\(''([^'']+)''.*\)', '\1'),
-                    '^("([^"]|"")*"\.|[^.]*\.)', ''
-                ),
-                '^"(.*)"$', '\1'
-            ),
-            '""', '"'
-        ) AS sequence_name
-    FROM information_schema.columns col
-    WHERE col.table_schema = $1
-      AND col.column_default LIKE '%nextval%'
-) col_table ON col_table.sequence_name = s.sequencename
 WHERE s.schemaname = $1
 ORDER BY s.schemaname, s.sequencename
 `
@@ -3041,8 +3023,9 @@ type GetSequencesForSchemaRow struct {
 }
 
 // GetSequencesForSchema retrieves all sequences for a specific schema
-// Method 1: Try to find dependency relationship (for proper SERIAL columns)
-// Method 2: Find sequences used in column defaults (for nextval() patterns)
+// Ownership comes only from pg_depend (SERIAL / OWNED BY / identity). A
+// sequence merely referenced by a column DEFAULT nextval() is not owned by
+// that column and must be dumped and created explicitly (issue #573).
 func (q *Queries) GetSequencesForSchema(ctx context.Context, dollar_1 sql.NullString) ([]GetSequencesForSchemaRow, error) {
 	rows, err := q.db.QueryContext(ctx, getSequencesForSchema, dollar_1)
 	if err != nil {

--- a/ir/queries/queries_test.go
+++ b/ir/queries/queries_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestGetSequencesForSchemaDetectsMixedCaseSequenceInColumnDefault(t *testing.T) {
+func TestGetSequencesForSchemaOwnershipComesFromPgDepend(t *testing.T) {
 	conn, _, _, _, _, _ := testutil.ConnectToPostgres(t, sharedTestPostgres)
 	defer conn.Close()
 
@@ -30,36 +30,40 @@ func TestGetSequencesForSchemaDetectsMixedCaseSequenceInColumnDefault(t *testing
 	if _, err := conn.ExecContext(ctx, `CREATE TABLE orders ("orderId" SERIAL PRIMARY KEY)`); err != nil {
 		t.Fatalf("failed to create test table: %v", err)
 	}
-	// Drop the pg_depend ownership edge that SERIAL creates automatically.
-	// GetSequencesForSchema detects ownership via two paths: pg_depend (primary)
-	// and column_default parsing (fallback). Without this, pg_depend resolves
-	// ownership before the column_default regex is ever reached, so the test
-	// would pass even with the broken regex. OWNED BY NONE forces the fallback
-	// path — the one that was broken for mixed-case identifiers before this fix.
+
+	findSeq := func() queries.GetSequencesForSchemaRow {
+		rows, err := queries.New(conn).GetSequencesForSchema(ctx, sql.NullString{String: "public", Valid: true})
+		if err != nil {
+			t.Fatalf("failed to get sequences for schema: %v", err)
+		}
+		for _, row := range rows {
+			if row.SequenceName.String == "orders_orderId_seq" {
+				return row
+			}
+		}
+		t.Fatalf("sequence %q not found; got sequences: %s", "orders_orderId_seq", sequenceNames(rows))
+		return queries.GetSequencesForSchemaRow{}
+	}
+
+	// SERIAL records ownership in pg_depend, including mixed-case column names.
+	row := findSeq()
+	if row.OwnedByTable.String != "orders" {
+		t.Fatalf("OwnedByTable = %q, want %q", row.OwnedByTable.String, "orders")
+	}
+	if row.OwnedByColumn.String != "orderId" {
+		t.Fatalf("OwnedByColumn = %q, want %q", row.OwnedByColumn.String, "orderId")
+	}
+
+	// Once the pg_depend edge is gone, the sequence is unowned even though the
+	// column default still references it. Ownership must not be inferred from
+	// column defaults (issue #573).
 	if _, err := conn.ExecContext(ctx, `ALTER SEQUENCE "orders_orderId_seq" OWNED BY NONE`); err != nil {
 		t.Fatalf("failed to remove sequence ownership dependency: %v", err)
 	}
-
-	rows, err := queries.New(conn).GetSequencesForSchema(ctx, sql.NullString{String: "public", Valid: true})
-	if err != nil {
-		t.Fatalf("failed to get sequences for schema: %v", err)
+	row = findSeq()
+	if row.OwnedByTable.String != "" || row.OwnedByColumn.String != "" {
+		t.Fatalf("expected no ownership after OWNED BY NONE, got table=%q column=%q", row.OwnedByTable.String, row.OwnedByColumn.String)
 	}
-
-	for _, row := range rows {
-		if row.SequenceName.String != "orders_orderId_seq" {
-			continue
-		}
-
-		if !row.OwnedByTable.Valid || row.OwnedByTable.String != "orders" {
-			t.Fatalf("OwnedByTable = %q, want %q", row.OwnedByTable.String, "orders")
-		}
-		if !row.OwnedByColumn.Valid || row.OwnedByColumn.String != "orderId" {
-			t.Fatalf("OwnedByColumn = %q, want %q", row.OwnedByColumn.String, "orderId")
-		}
-		return
-	}
-
-	t.Fatalf("sequence %q not found; got sequences: %s", "orders_orderId_seq", sequenceNames(rows))
 }
 
 func sequenceNames(rows []queries.GetSequencesForSchemaRow) string {

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/diff.sql
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/diff.sql
@@ -1,4 +1,5 @@
 CREATE SEQUENCE IF NOT EXISTS hibernate_sequence;
+CREATE SEQUENCE IF NOT EXISTS legacy_code_custom_seq;
 CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;
 CREATE SEQUENCE IF NOT EXISTS widget_custom_seq;
 CREATE TABLE IF NOT EXISTS audit_log (
@@ -26,4 +27,6 @@ CREATE TABLE IF NOT EXISTS widget (
     label text,
     CONSTRAINT widget_pkey PRIMARY KEY (id)
 );
+ALTER TABLE legacy ADD COLUMN code integer DEFAULT nextval('legacy_code_custom_seq'::regclass) NOT NULL;
+ALTER SEQUENCE legacy_code_custom_seq OWNED BY legacy.code;
 ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/diff.sql
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/diff.sql
@@ -1,0 +1,29 @@
+CREATE SEQUENCE IF NOT EXISTS hibernate_sequence;
+CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;
+CREATE SEQUENCE IF NOT EXISTS widget_custom_seq;
+CREATE TABLE IF NOT EXISTS audit_log (
+    id BIGSERIAL,
+    message text,
+    CONSTRAINT audit_log_pkey PRIMARY KEY (id)
+);
+CREATE TABLE IF NOT EXISTS instance (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass),
+    name text,
+    CONSTRAINT instance_pkey PRIMARY KEY (id)
+);
+CREATE TABLE IF NOT EXISTS reference (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass),
+    title text,
+    CONSTRAINT reference_pkey PRIMARY KEY (id)
+);
+CREATE TABLE IF NOT EXISTS shard_config (
+    id bigint DEFAULT nextval('hibernate_sequence'::regclass),
+    name varchar(255) NOT NULL,
+    CONSTRAINT shard_config_pkey PRIMARY KEY (id)
+);
+CREATE TABLE IF NOT EXISTS widget (
+    id integer DEFAULT nextval('widget_custom_seq'::regclass),
+    label text,
+    CONSTRAINT widget_pkey PRIMARY KEY (id)
+);
+ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/new.sql
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/new.sql
@@ -1,0 +1,56 @@
+-- Issue #573/#574/#576: sequences referenced by column defaults but not owned by
+-- the column must be emitted explicitly. Only sequences genuinely created by
+-- SERIAL (owned via pg_depend and named <table>_<column>_seq) may be collapsed
+-- into the SERIAL shorthand.
+
+-- One shared sequence feeding several tables (Hibernate-style global id)
+CREATE SEQUENCE nsl_global_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE SEQUENCE hibernate_sequence
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE TABLE instance (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass) NOT NULL,
+    name text,
+    CONSTRAINT instance_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE reference (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass) NOT NULL,
+    title text,
+    CONSTRAINT reference_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE shard_config (
+    id bigint DEFAULT nextval('hibernate_sequence'::regclass) NOT NULL,
+    name character varying(255) NOT NULL,
+    CONSTRAINT shard_config_pkey PRIMARY KEY (id)
+);
+
+-- Sequence owned by the column but with a custom name: CREATE TABLE ... SERIAL
+-- would create widget_id_seq instead, so it must stay explicit as well.
+CREATE SEQUENCE widget_custom_seq;
+
+CREATE TABLE widget (
+    id integer DEFAULT nextval('widget_custom_seq'::regclass) NOT NULL,
+    label text,
+    CONSTRAINT widget_pkey PRIMARY KEY (id)
+);
+
+ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;
+
+-- Genuine SERIAL column for contrast: keeps the shorthand
+CREATE TABLE audit_log (
+    id bigserial NOT NULL,
+    message text,
+    CONSTRAINT audit_log_pkey PRIMARY KEY (id)
+);

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/new.sql
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/new.sql
@@ -54,3 +54,16 @@ CREATE TABLE audit_log (
     message text,
     CONSTRAINT audit_log_pkey PRIMARY KEY (id)
 );
+
+-- Existing table gains a column whose default is a custom-named sequence that
+-- is OWNED BY the new column: the sequence must be created before the column
+-- default references it, and the OWNED BY applied after ALTER TABLE ADD COLUMN.
+CREATE SEQUENCE legacy_code_custom_seq;
+
+CREATE TABLE legacy (
+    id bigint NOT NULL,
+    code integer DEFAULT nextval('legacy_code_custom_seq'::regclass) NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);
+
+ALTER SEQUENCE legacy_code_custom_seq OWNED BY legacy.code;

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/old.sql
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/old.sql
@@ -1,0 +1,5 @@
+-- Existing table that gains a column backed by a custom-named owned sequence
+CREATE TABLE legacy (
+    id bigint NOT NULL,
+    CONSTRAINT legacy_pkey PRIMARY KEY (id)
+);

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.json
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.json
@@ -3,7 +3,7 @@
   "pgschema_version": "1.12.5",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
-    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+    "hash": "a44dd50da2d4bd05b38e2c7bb4dc0e7cfac0908ce57e4c5766fa72e31f866d54"
   },
   "groups": [
     {
@@ -13,6 +13,12 @@
           "type": "sequence",
           "operation": "create",
           "path": "public.hibernate_sequence"
+        },
+        {
+          "sql": "CREATE SEQUENCE IF NOT EXISTS legacy_code_custom_seq;",
+          "type": "sequence",
+          "operation": "create",
+          "path": "public.legacy_code_custom_seq"
         },
         {
           "sql": "CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;",
@@ -55,6 +61,18 @@
           "type": "table",
           "operation": "create",
           "path": "public.widget"
+        },
+        {
+          "sql": "ALTER TABLE legacy ADD COLUMN code integer DEFAULT nextval('legacy_code_custom_seq'::regclass) NOT NULL;",
+          "type": "table.column",
+          "operation": "create",
+          "path": "public.legacy.code"
+        },
+        {
+          "sql": "ALTER SEQUENCE legacy_code_custom_seq OWNED BY legacy.code;",
+          "type": "sequence",
+          "operation": "create",
+          "path": "public.legacy_code_custom_seq"
         },
         {
           "sql": "ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;",

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.json
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.json
@@ -1,0 +1,68 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.5",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE SEQUENCE IF NOT EXISTS hibernate_sequence;",
+          "type": "sequence",
+          "operation": "create",
+          "path": "public.hibernate_sequence"
+        },
+        {
+          "sql": "CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;",
+          "type": "sequence",
+          "operation": "create",
+          "path": "public.nsl_global_seq"
+        },
+        {
+          "sql": "CREATE SEQUENCE IF NOT EXISTS widget_custom_seq;",
+          "type": "sequence",
+          "operation": "create",
+          "path": "public.widget_custom_seq"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS audit_log (\n    id BIGSERIAL,\n    message text,\n    CONSTRAINT audit_log_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.audit_log"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS instance (\n    id bigint DEFAULT nextval('nsl_global_seq'::regclass),\n    name text,\n    CONSTRAINT instance_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.instance"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS reference (\n    id bigint DEFAULT nextval('nsl_global_seq'::regclass),\n    title text,\n    CONSTRAINT reference_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.reference"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS shard_config (\n    id bigint DEFAULT nextval('hibernate_sequence'::regclass),\n    name varchar(255) NOT NULL,\n    CONSTRAINT shard_config_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.shard_config"
+        },
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS widget (\n    id integer DEFAULT nextval('widget_custom_seq'::regclass),\n    label text,\n    CONSTRAINT widget_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.widget"
+        },
+        {
+          "sql": "ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;",
+          "type": "sequence",
+          "operation": "create",
+          "path": "public.widget_custom_seq"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.sql
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.sql
@@ -1,0 +1,37 @@
+CREATE SEQUENCE IF NOT EXISTS hibernate_sequence;
+
+CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;
+
+CREATE SEQUENCE IF NOT EXISTS widget_custom_seq;
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id BIGSERIAL,
+    message text,
+    CONSTRAINT audit_log_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS instance (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass),
+    name text,
+    CONSTRAINT instance_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS reference (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass),
+    title text,
+    CONSTRAINT reference_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS shard_config (
+    id bigint DEFAULT nextval('hibernate_sequence'::regclass),
+    name varchar(255) NOT NULL,
+    CONSTRAINT shard_config_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS widget (
+    id integer DEFAULT nextval('widget_custom_seq'::regclass),
+    label text,
+    CONSTRAINT widget_pkey PRIMARY KEY (id)
+);
+
+ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.sql
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.sql
@@ -1,5 +1,7 @@
 CREATE SEQUENCE IF NOT EXISTS hibernate_sequence;
 
+CREATE SEQUENCE IF NOT EXISTS legacy_code_custom_seq;
+
 CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;
 
 CREATE SEQUENCE IF NOT EXISTS widget_custom_seq;
@@ -33,5 +35,9 @@ CREATE TABLE IF NOT EXISTS widget (
     label text,
     CONSTRAINT widget_pkey PRIMARY KEY (id)
 );
+
+ALTER TABLE legacy ADD COLUMN code integer DEFAULT nextval('legacy_code_custom_seq'::regclass) NOT NULL;
+
+ALTER SEQUENCE legacy_code_custom_seq OWNED BY legacy.code;
 
 ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.txt
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.txt
@@ -1,0 +1,59 @@
+Plan: 9 to add.
+
+Summary by type:
+  sequences: 4 to add
+  tables: 5 to add
+
+Sequences:
+  + hibernate_sequence
+  + nsl_global_seq
+  + widget_custom_seq
+  + widget_custom_seq
+
+Tables:
+  + audit_log
+  + instance
+  + reference
+  + shard_config
+  + widget
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE SEQUENCE IF NOT EXISTS hibernate_sequence;
+
+CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;
+
+CREATE SEQUENCE IF NOT EXISTS widget_custom_seq;
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id BIGSERIAL,
+    message text,
+    CONSTRAINT audit_log_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS instance (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass),
+    name text,
+    CONSTRAINT instance_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS reference (
+    id bigint DEFAULT nextval('nsl_global_seq'::regclass),
+    title text,
+    CONSTRAINT reference_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS shard_config (
+    id bigint DEFAULT nextval('hibernate_sequence'::regclass),
+    name varchar(255) NOT NULL,
+    CONSTRAINT shard_config_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS widget (
+    id integer DEFAULT nextval('widget_custom_seq'::regclass),
+    label text,
+    CONSTRAINT widget_pkey PRIMARY KEY (id)
+);
+
+ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;

--- a/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.txt
+++ b/testdata/diff/create_sequence/issue_573_shared_sequence_default/plan.txt
@@ -1,18 +1,20 @@
-Plan: 9 to add.
+Plan: 9 to add, 1 to modify.
 
 Summary by type:
   sequences: 4 to add
-  tables: 5 to add
+  tables: 5 to add, 1 to modify
 
 Sequences:
   + hibernate_sequence
+  + legacy_code_custom_seq
   + nsl_global_seq
-  + widget_custom_seq
   + widget_custom_seq
 
 Tables:
   + audit_log
   + instance
+  ~ legacy
+    + code (column)
   + reference
   + shard_config
   + widget
@@ -21,6 +23,8 @@ DDL to be executed:
 --------------------------------------------------
 
 CREATE SEQUENCE IF NOT EXISTS hibernate_sequence;
+
+CREATE SEQUENCE IF NOT EXISTS legacy_code_custom_seq;
 
 CREATE SEQUENCE IF NOT EXISTS nsl_global_seq;
 
@@ -55,5 +59,9 @@ CREATE TABLE IF NOT EXISTS widget (
     label text,
     CONSTRAINT widget_pkey PRIMARY KEY (id)
 );
+
+ALTER TABLE legacy ADD COLUMN code integer DEFAULT nextval('legacy_code_custom_seq'::regclass) NOT NULL;
+
+ALTER SEQUENCE legacy_code_custom_seq OWNED BY legacy.code;
 
 ALTER SEQUENCE widget_custom_seq OWNED BY widget.id;

--- a/testdata/dump/sakila/pgschema.sql
+++ b/testdata/dump/sakila/pgschema.sql
@@ -32,11 +32,89 @@ CREATE DOMAIN year AS integer
   CONSTRAINT year_check CHECK (VALUE >= 1901 AND VALUE <= 2155);
 
 --
+-- Name: actor_actor_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS actor_actor_id_seq;
+
+--
+-- Name: address_address_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS address_address_id_seq;
+
+--
+-- Name: category_category_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS category_category_id_seq;
+
+--
+-- Name: city_city_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS city_city_id_seq;
+
+--
+-- Name: country_country_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS country_country_id_seq;
+
+--
+-- Name: customer_customer_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS customer_customer_id_seq;
+
+--
+-- Name: film_film_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS film_film_id_seq;
+
+--
+-- Name: inventory_inventory_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS inventory_inventory_id_seq;
+
+--
+-- Name: language_language_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS language_language_id_seq;
+
+--
+-- Name: payment_payment_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS payment_payment_id_seq;
+
+--
+-- Name: rental_rental_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS rental_rental_id_seq;
+
+--
+-- Name: staff_staff_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS staff_staff_id_seq;
+
+--
+-- Name: store_store_id_seq; Type: SEQUENCE; Schema: -; Owner: -
+--
+
+CREATE SEQUENCE IF NOT EXISTS store_store_id_seq;
+
+--
 -- Name: actor; Type: TABLE; Schema: -; Owner: -
 --
 
 CREATE TABLE IF NOT EXISTS actor (
-    actor_id SERIAL,
+    actor_id integer DEFAULT nextval('actor_actor_id_seq'::regclass),
     first_name text NOT NULL,
     last_name text NOT NULL,
     last_update timestamptz DEFAULT now() NOT NULL,
@@ -54,7 +132,7 @@ CREATE INDEX IF NOT EXISTS idx_actor_last_name ON actor (last_name);
 --
 
 CREATE TABLE IF NOT EXISTS category (
-    category_id SERIAL,
+    category_id integer DEFAULT nextval('category_category_id_seq'::regclass),
     name text NOT NULL,
     last_update timestamptz DEFAULT now() NOT NULL,
     CONSTRAINT category_pkey PRIMARY KEY (category_id)
@@ -65,7 +143,7 @@ CREATE TABLE IF NOT EXISTS category (
 --
 
 CREATE TABLE IF NOT EXISTS country (
-    country_id SERIAL,
+    country_id integer DEFAULT nextval('country_country_id_seq'::regclass),
     country text NOT NULL,
     last_update timestamptz DEFAULT now() NOT NULL,
     CONSTRAINT country_pkey PRIMARY KEY (country_id)
@@ -76,7 +154,7 @@ CREATE TABLE IF NOT EXISTS country (
 --
 
 CREATE TABLE IF NOT EXISTS city (
-    city_id SERIAL,
+    city_id integer DEFAULT nextval('city_city_id_seq'::regclass),
     city text NOT NULL,
     country_id integer NOT NULL,
     last_update timestamptz DEFAULT now() NOT NULL,
@@ -95,7 +173,7 @@ CREATE INDEX IF NOT EXISTS idx_fk_country_id ON city (country_id);
 --
 
 CREATE TABLE IF NOT EXISTS address (
-    address_id SERIAL,
+    address_id integer DEFAULT nextval('address_address_id_seq'::regclass),
     address text NOT NULL,
     address2 text,
     district text NOT NULL,
@@ -118,7 +196,7 @@ CREATE INDEX IF NOT EXISTS idx_fk_city_id ON address (city_id);
 --
 
 CREATE TABLE IF NOT EXISTS language (
-    language_id SERIAL,
+    language_id integer DEFAULT nextval('language_language_id_seq'::regclass),
     name character(20) NOT NULL,
     last_update timestamptz DEFAULT now() NOT NULL,
     CONSTRAINT language_pkey PRIMARY KEY (language_id)
@@ -129,7 +207,7 @@ CREATE TABLE IF NOT EXISTS language (
 --
 
 CREATE TABLE IF NOT EXISTS film (
-    film_id SERIAL,
+    film_id integer DEFAULT nextval('film_film_id_seq'::regclass),
     title text NOT NULL,
     description text,
     release_year year,
@@ -209,7 +287,7 @@ CREATE TABLE IF NOT EXISTS film_category (
 --
 
 CREATE TABLE IF NOT EXISTS payment (
-    payment_id SERIAL,
+    payment_id integer DEFAULT nextval('payment_payment_id_seq'::regclass),
     customer_id integer NOT NULL,
     staff_id integer NOT NULL,
     rental_id integer NOT NULL,
@@ -223,7 +301,7 @@ CREATE TABLE IF NOT EXISTS payment (
 --
 
 CREATE TABLE IF NOT EXISTS store (
-    store_id SERIAL,
+    store_id integer DEFAULT nextval('store_store_id_seq'::regclass),
     manager_staff_id integer NOT NULL,
     address_id integer NOT NULL,
     last_update timestamptz DEFAULT now() NOT NULL,
@@ -242,7 +320,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_unq_manager_staff_id ON store (manager_sta
 --
 
 CREATE TABLE IF NOT EXISTS customer (
-    customer_id SERIAL,
+    customer_id integer DEFAULT nextval('customer_customer_id_seq'::regclass),
     store_id integer NOT NULL,
     first_name text NOT NULL,
     last_name text NOT NULL,
@@ -280,7 +358,7 @@ CREATE INDEX IF NOT EXISTS idx_last_name ON customer (last_name);
 --
 
 CREATE TABLE IF NOT EXISTS inventory (
-    inventory_id SERIAL,
+    inventory_id integer DEFAULT nextval('inventory_inventory_id_seq'::regclass),
     film_id integer NOT NULL,
     store_id integer NOT NULL,
     last_update timestamptz DEFAULT now() NOT NULL,
@@ -300,7 +378,7 @@ CREATE INDEX IF NOT EXISTS idx_store_id_film_id ON inventory (store_id, film_id)
 --
 
 CREATE TABLE IF NOT EXISTS staff (
-    staff_id SERIAL,
+    staff_id integer DEFAULT nextval('staff_staff_id_seq'::regclass),
     first_name text NOT NULL,
     last_name text NOT NULL,
     address_id integer NOT NULL,
@@ -321,7 +399,7 @@ CREATE TABLE IF NOT EXISTS staff (
 --
 
 CREATE TABLE IF NOT EXISTS rental (
-    rental_id SERIAL,
+    rental_id integer DEFAULT nextval('rental_rental_id_seq'::regclass),
     rental_date timestamptz NOT NULL,
     inventory_id integer NOT NULL,
     customer_id integer NOT NULL,


### PR DESCRIPTION
## Summary

pgschema treated any integer column with a `nextval()` default as a SERIAL column, and the sequence inspector query synthesized "ownership" for any sequence merely referenced by a column default. As a result a shared sequence (Hibernate-style `nsl_global_seq` used by many tables) or a custom-named sequence disappeared from dumps and plans while the column was rendered as `SERIAL`/`BIGSERIAL`. On apply PostgreSQL created `<table>_<column>_seq` and rewired the default to it, so plans were wrong and not idempotent.

Changes:
- **Inspector query**: ownership now comes only from `pg_depend` (SERIAL / `OWNED BY` / identity). The fallback join that inferred ownership from `column_default LIKE '%nextval%'` is removed.
- **IR**: new `Column.IsSerial`, set during normalization only when the default's sequence is owned by the column *and* has PostgreSQL's default `<table>_<column>_seq` name (with `makeObjectName` truncation). Only such columns render as SERIAL; everything else keeps its explicit `DEFAULT nextval(...)` and gets an explicit `CREATE SEQUENCE`.
- **Diff**: the "skip sequence, CREATE TABLE will create it" logic keys off `IsSerial` instead of raw ownership. For an explicitly created sequence whose owning column is created in the same migration, `OWNED BY` is deferred to an `ALTER SEQUENCE ... OWNED BY` after the tables, matching pg_dump ordering.

The Sakila dump fixture changes because that schema declares its sequences explicitly without `OWNED BY`; they are now dumped explicitly, which is the faithful representation (SERIAL would have made them owned on re-apply).

Fixes #573
Fixes #574
Fixes #576

## Test plan

- New `testdata/diff/create_sequence/issue_573_shared_sequence_default` covering a shared sequence used by several tables, a custom-named owned sequence, and a genuine `bigserial` for contrast. Passes plan, apply, and the second-plan idempotency check.
- New unit tests for `serialSequenceName`, `nextvalSequenceName`, and `markSerialColumns`.

```bash
PGSCHEMA_TEST_FILTER="create_sequence/issue_573" go test -v ./internal/diff -run TestDiffFromFiles
PGSCHEMA_TEST_FILTER="create_sequence/issue_573" go test -v ./cmd -run TestPlanAndApply
go test ./ir
go test ./internal/diff
go test ./cmd/dump
```

All of the above pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)