### PR TITLE
fix: order aggregates and SQL function bodies after the views they depend on (#580)

### DIFF
--- a/cmd/dump/aggregate_identity_integration_test.go
+++ b/cmd/dump/aggregate_identity_integration_test.go
@@ -1,0 +1,60 @@
+package dump
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pgplex/pgschema/ir"
+	"github.com/pgplex/pgschema/testutil"
+)
+
+// TestAggregateIdentityArgsQuotedSchema verifies that an aggregate over a
+// relation row type inspects with unqualified identity arguments even when its
+// schema needs quoting. The inspecting connection does not have the schema on
+// its search_path, so PostgreSQL renders the type as "MySchema".v; both that
+// and the public.v form must normalize to v, or every plan would drop and
+// recreate the aggregate (#580 review).
+func TestAggregateIdentityArgsQuotedSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	embeddedPG := testutil.SetupPostgres(t)
+	defer embeddedPG.Stop()
+
+	conn, _, _, _, _, _ := testutil.ConnectToPostgres(t, embeddedPG)
+	defer conn.Close()
+
+	ctx := context.Background()
+	setup := `
+CREATE SCHEMA "MySchema";
+CREATE TABLE "MySchema".t (id integer);
+CREATE VIEW "MySchema".v AS SELECT id FROM "MySchema".t;
+CREATE FUNCTION "MySchema".v_step(state integer, r "MySchema".v) RETURNS integer
+    LANGUAGE sql IMMUTABLE AS $$ SELECT state + r.id $$;
+CREATE AGGREGATE "MySchema".sum_v("MySchema".v) (SFUNC = "MySchema".v_step, STYPE = integer, INITCOND = '0');
+`
+	if _, err := conn.ExecContext(ctx, setup); err != nil {
+		t.Fatalf("Failed to set up schema: %v", err)
+	}
+
+	schemaIR, err := ir.NewInspector(conn, nil).BuildIR(ctx, "MySchema")
+	if err != nil {
+		t.Fatalf("BuildIR failed: %v", err)
+	}
+	dbSchema := schemaIR.Schemas["MySchema"]
+	if dbSchema == nil {
+		t.Fatalf("schema \"MySchema\" not found in IR; got %v", schemaIR.Schemas)
+	}
+	agg, ok := dbSchema.Aggregates["sum_v(v)"]
+	if !ok {
+		var keys []string
+		for k := range dbSchema.Aggregates {
+			keys = append(keys, k)
+		}
+		t.Fatalf("expected aggregate key %q, got %v", "sum_v(v)", keys)
+	}
+	if agg.Arguments != "v" || agg.Signature != "v" {
+		t.Errorf("expected Arguments and Signature %q, got Arguments=%q Signature=%q", "v", agg.Arguments, agg.Signature)
+	}
+}

--- a/cmd/dump/multifile_integration_test.go
+++ b/cmd/dump/multifile_integration_test.go
@@ -79,6 +79,13 @@ CREATE TABLE t (id int, name text);
 CREATE VIEW tnu_index_v AS SELECT id, name FROM t;
 CREATE FUNCTION gettnu(tnu_name text) RETURNS SETOF tnu_index_v LANGUAGE sql AS $$
 SELECT * FROM tnu_index_v WHERE name ~ tnu_name $$;
+
+-- Issue #580 follow-up: SQL-language function whose body queries a view, and
+-- an aggregate whose input type is a view's row type (with a transition
+-- function that takes the row type too). Both are ordered by the diff package.
+CREATE FUNCTION count_tnu() RETURNS bigint LANGUAGE sql AS $$ SELECT count(*) FROM tnu_index_v $$;
+CREATE FUNCTION tnu_sfunc(state int, r tnu_index_v) RETURNS int LANGUAGE sql IMMUTABLE AS $$ SELECT state + r.id $$;
+CREATE AGGREGATE sum_tnu(tnu_index_v) (SFUNC = tnu_sfunc, STYPE = int, INITCOND = '0');
 `
 	if _, err := conn.ExecContext(ctx, setup); err != nil {
 		t.Fatalf("Failed to set up schema: %v", err)
@@ -139,6 +146,10 @@ SELECT * FROM tnu_index_v WHERE name ~ tnu_name $$;
 	// Body-based dependency of a SQL-language function (#530 ordering).
 	mustPrecede("functions/default_label.sql", "tables/labeled.sql")
 	mustPrecede("tables/labeled.sql", "functions/count_labeled.sql")
+	// Diff-package ordering for view dependencies (#580 follow-up).
+	mustPrecede("views/tnu_index_v.sql", "functions/count_tnu.sql")
+	mustPrecede("views/tnu_index_v.sql", "functions/tnu_sfunc.sql")
+	mustPrecede("functions/tnu_sfunc.sql", "aggregates/sum_tnu.sql")
 
 	// Replay the multi-file dump into an empty schema in include order.
 	if _, err := conn.ExecContext(ctx, `DROP SCHEMA public CASCADE; CREATE SCHEMA public;`); err != nil {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -3394,8 +3394,10 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 // INSERT INTO table, UPDATE [ONLY] table, DELETE FROM table, TABLE table.
 // Captures the table name (possibly schema-qualified) in group 1.
 // relationKeywordPattern finds the keywords that introduce a relation or a
-// relation list: FROM, JOIN, INTO, UPDATE, DELETE FROM, TABLE.
-var relationKeywordPattern = regexp.MustCompile(`(?i)\b(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE)\s+`)
+// relation list: FROM, JOIN, INTO, UPDATE, DELETE FROM, TABLE, and the USING
+// of DELETE and MERGE (a JOIN's USING is always followed by a column list in
+// parentheses and is skipped by relationReferences).
+var relationKeywordPattern = regexp.MustCompile(`(?i)\b(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE|USING)\s+`)
 
 // qualifiedIdentExpr matches a possibly quoted, possibly schema-qualified identifier.
 const qualifiedIdentExpr = `(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\s*\.\s*(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*`
@@ -3416,8 +3418,12 @@ func relationReferences(body string) []string {
 	for _, loc := range relationKeywordPattern.FindAllStringIndex(body, -1) {
 		// After INTO the next token is always a relation, so "t(a, b)" is a
 		// column list, not a function call.
-		callAllowed := !strings.Contains(strings.ToUpper(body[loc[0]:loc[1]]), "INTO")
-		i := loc[1]
+		keyword := strings.ToUpper(strings.TrimSpace(body[loc[0]:loc[1]]))
+		callAllowed := keyword != "INTO"
+		i := skipSpaces(body, loc[1])
+		if keyword == "USING" && i < len(body) && body[i] == '(' {
+			continue // JOIN ... USING (columns), not a relation source
+		}
 		for {
 			i = skipSpaces(body, i)
 			if keywordAt(body, i, "ONLY") {
@@ -3439,6 +3445,11 @@ func relationReferences(body string) []string {
 				i += len(name)
 				if callAllowed && i < len(body) && body[i] == '(' {
 					i = matchingParen(body, i) + 1 // function call, not a relation
+					if k := skipSpaces(body, i); keywordAt(body, k, "WITH") {
+						if k = skipSpaces(body, k+len("WITH")); keywordAt(body, k, "ORDINALITY") {
+							i = k + len("ORDINALITY")
+						}
+					}
 				} else {
 					refs = append(refs, name)
 				}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -312,8 +312,9 @@ type ddlDiff struct {
 	// Newly-added views that reference newly-added columns on modified tables.
 	// Created in the modify phase, AFTER generateModifyTablesSQL, so the columns
 	// exist when the view body is parsed (issue #414).
-	deferredAddedViews             []*ir.View
-	functionsAwaitingDeferredViews []*ir.Function
+	deferredAddedViews              []*ir.View
+	functionsAwaitingDeferredViews  []*ir.Function
+	aggregatesAwaitingDeferredViews []*ir.Aggregate
 	// Added functions whose return/parameter type references a view being recreated
 	// (DROP + CREATE) by this migration. For a function whose signature changed, its
 	// old definition is dropped in the drop phase; creating the new one in the create
@@ -2051,7 +2052,21 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// Create aggregates after their transition/final functions AND all tables exist
 	// (an aggregate may use a new table's row type as an argument or state type), and
 	// before views, which may reference the aggregates in their definitions.
-	generateCreateAggregatesSQL(d.addedAggregates, targetSchema, collector)
+	// Aggregates whose argument, state, or return type is a new view's row type
+	// are held back until the view and the view-dependent functions exist (#580).
+	aggregatesToCreateNow := d.addedAggregates
+	var aggregatesWithViewDeps []*ir.Aggregate
+	if len(newViewLookup) > 0 {
+		aggregatesToCreateNow = nil
+		for _, agg := range d.addedAggregates {
+			if aggregateReferencesNewView(agg, newViewLookup) {
+				aggregatesWithViewDeps = append(aggregatesWithViewDeps, agg)
+			} else {
+				aggregatesToCreateNow = append(aggregatesToCreateNow, agg)
+			}
+		}
+	}
+	generateCreateAggregatesSQL(aggregatesToCreateNow, targetSchema, collector)
 
 	// Merge deferred policies from all batches
 	allDeferredPolicies := append(append(deferredPolicies1, deferredPolicies2...), deferredPolicies3...)
@@ -2117,11 +2132,25 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 			}
 		}
 		functionsWithViewDeps = keepNow
+
+		var keepAggs []*ir.Aggregate
+		for _, agg := range aggregatesWithViewDeps {
+			if aggregateReferencesNewView(agg, deferredViewLookup) {
+				d.aggregatesAwaitingDeferredViews = append(d.aggregatesAwaitingDeferredViews, agg)
+			} else {
+				keepAggs = append(keepAggs, agg)
+			}
+		}
+		aggregatesWithViewDeps = keepAggs
 	}
 
 	// Create functions WITH view dependencies (now that views exist)
 	// These functions reference views in their return type or parameter types (issue #300)
 	generateCreateFunctionsSQL(functionsWithViewDeps, targetSchema, collector)
+
+	// Create aggregates that use a new view's row type, after the view and after
+	// any transition/final function that takes the row type as well (#580).
+	generateCreateAggregatesSQL(aggregatesWithViewDeps, targetSchema, collector)
 
 	// Revoke default grants on new tables that the user explicitly didn't include
 	// This must happen AFTER tables are created but BEFORE explicit grants
@@ -2179,6 +2208,9 @@ func (d *ddlDiff) generateModifySQL(targetSchema string, collector *diffCollecto
 	}
 	if len(d.functionsAwaitingDeferredViews) > 0 {
 		generateCreateFunctionsSQL(d.functionsAwaitingDeferredViews, targetSchema, collector)
+	}
+	if len(d.aggregatesAwaitingDeferredViews) > 0 {
+		generateCreateAggregatesSQL(d.aggregatesAwaitingDeferredViews, targetSchema, collector)
 	}
 
 	// Find views that depend on views being recreated (issue #268, #308)
@@ -2656,7 +2688,48 @@ func buildRecreatedViewLookup(modifiedViews []*viewDiff) map[string]struct{} {
 // in its return type or parameter types. This handles cases where functions use
 // view composite types (e.g., RETURNS SETOF view_name or parameter of view_name type).
 func functionReferencesNewView(fn *ir.Function, newViews map[string]struct{}) bool {
-	return functionSignatureReferencesRelation(fn, newViews)
+	if functionSignatureReferencesRelation(fn, newViews) {
+		return true
+	}
+	// A SQL-language body is resolved against the catalog when the function is
+	// created, so querying a new view is a creation-time dependency. Other
+	// languages (plpgsql) resolve relations at run time; treating their body
+	// mentions as dependencies would push trigger functions past the triggers
+	// that reference them, since triggers are created before views (#580).
+	if fn == nil || !strings.EqualFold(fn.Language, "sql") || fn.Definition == "" {
+		return false
+	}
+	return bodyReferencesRelation(fn.Definition, newViews)
+}
+
+// bodyReferencesRelation scans a function body for FROM/JOIN/INTO/UPDATE/TABLE
+// references to a relation in the lookup.
+func bodyReferencesRelation(body string, relations map[string]struct{}) bool {
+	for _, match := range tableRefPattern.FindAllStringSubmatch(body, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		if _, ok := relations[strings.ToLower(match[1])]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// aggregateReferencesNewView reports whether an aggregate's argument, state,
+// moving-state, or return type is a new view's row type. Such an aggregate must
+// be created after the view (#580).
+func aggregateReferencesNewView(agg *ir.Aggregate, newViews map[string]struct{}) bool {
+	if agg == nil || len(newViews) == 0 {
+		return false
+	}
+	candidates := append([]string{agg.StateType, agg.MStateType, agg.ReturnType}, strings.Split(agg.Arguments, ",")...)
+	for _, typ := range candidates {
+		if typeMatchesLookup(extractBaseTypeName(typ), agg.Schema, newViews) {
+			return true
+		}
+	}
+	return false
 }
 
 // RelationLookup builds a case-insensitive lookup of table and view names, keyed
@@ -3090,19 +3163,9 @@ func functionReferencesNewTable(fn *ir.Function, newTables map[string]struct{}) 
 		return false
 	}
 
-	matches := tableRefPattern.FindAllStringSubmatch(fn.Definition, -1)
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
-		}
-		ref := strings.ToLower(match[1])
-		// The lookup contains both qualified (schema.table) and unqualified
-		// (table) keys for each table, so a single check covers both forms.
-		if _, ok := newTables[ref]; ok {
-			return true
-		}
-	}
-	return false
+	// The lookup contains both qualified (schema.table) and unqualified
+	// (table) keys for each table, so a single check covers both forms.
+	return bodyReferencesRelation(fn.Definition, newTables)
 }
 
 // GetObjectName implementations for DiffSource interface

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2070,17 +2070,20 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	var aggregatesToCreateNow []*ir.Aggregate
 	aggregatesToCreateNow, d.aggregatesAwaitingRecreatedViews = splitAggregatesByViewDeps(d.addedAggregates, recreatedViewLookup, buildFunctionLookup(d.functionsAwaitingRecreatedViews))
 	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(aggregatesToCreateNow, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
-	generateCreateAggregatesSQL(aggregatesToCreateNow, targetSchema, collector)
-
 	// SQL-language functions that call an aggregate follow the batch that
-	// creates it: those calling only the aggregates above are created here, the
-	// rest join the view-dependent or recreated-view batch of their aggregate.
+	// creates it: callers of the aggregates created here stay here, the rest
+	// join the view-dependent or recreated-view batch of their aggregate. A
+	// view-dependent function calling a recreated-batch aggregate moves too.
 	var callersOfLateAggregates, callersOfRecreatedAggregates []*ir.Function
 	functionsCallingAggregates, callersOfLateAggregates = splitFunctionsCallingAggregates(functionsCallingAggregates, append(append([]*ir.Aggregate{}, aggregatesWithViewDeps...), d.aggregatesAwaitingRecreatedViews...))
 	callersOfLateAggregates, callersOfRecreatedAggregates = splitFunctionsCallingAggregates(callersOfLateAggregates, d.aggregatesAwaitingRecreatedViews)
 	functionsWithViewDeps = append(functionsWithViewDeps, callersOfLateAggregates...)
-	d.functionsAwaitingRecreatedViews = append(d.functionsAwaitingRecreatedViews, callersOfRecreatedAggregates...)
-	generateCreateFunctionsSQL(functionsCallingAggregates, targetSchema, collector)
+	functionsWithViewDeps, callersOfLateAggregates = splitFunctionsCallingAggregates(functionsWithViewDeps, d.aggregatesAwaitingRecreatedViews)
+	d.functionsAwaitingRecreatedViews = append(append(d.functionsAwaitingRecreatedViews, callersOfRecreatedAggregates...), callersOfLateAggregates...)
+
+	// Aggregates and their callers may chain (aggregate a -> SQL support
+	// function calling a -> aggregate b), so they are scheduled together.
+	generateFunctionsAndAggregatesSQL(functionsCallingAggregates, aggregatesToCreateNow, targetSchema, collector)
 
 	// Merge deferred policies from all batches
 	allDeferredPolicies := append(append(deferredPolicies1, deferredPolicies2...), deferredPolicies3...)
@@ -2715,8 +2718,19 @@ func bodyReferencesRelation(body string, relations map[string]struct{}) bool {
 		if len(match) < 2 {
 			continue
 		}
-		if _, ok := relations[normalizeRelationReference(match[1])]; ok {
-			return true
+		for _, item := range splitTopLevelCommas(match[1]) {
+			item = strings.TrimSpace(item)
+			if len(item) > 5 && strings.EqualFold(item[:5], "ONLY ") {
+				item = strings.TrimSpace(item[5:])
+			}
+			item = strings.TrimPrefix(item, "(")
+			name := leadingQualifiedIdent.FindString(item)
+			if name == "" {
+				continue
+			}
+			if _, ok := relations[normalizeRelationReference(name)]; ok {
+				return true
+			}
 		}
 	}
 	return false
@@ -2850,19 +2864,33 @@ func generateViewsAndDependentRoutinesSQL(views []*ir.View, functions []*ir.Func
 	lateViewLookup := buildViewLookup(viewsLater)
 	functionsNow, functionsLater := splitFunctionsByViewDeps(functions, lateViewLookup)
 	aggregatesNow, aggregatesLater := splitAggregatesByViewDeps(aggregates, lateViewLookup, buildFunctionLookup(functionsLater))
-	// Within each half, SQL-language functions that call one of the aggregates
-	// go after it; the aggregates' own support functions stay ahead of them.
-	functionsNow, functionsCallingNow := splitFunctionsCallingAggregates(functionsNow, aggregatesNow)
-	functionsLater, functionsCallingLater := splitFunctionsCallingAggregates(functionsLater, aggregatesLater)
 
 	generateCreateViewsSQL(viewsNow, targetSchema, collector)
-	generateCreateFunctionsSQL(functionsNow, targetSchema, collector)
-	generateCreateAggregatesSQL(aggregatesNow, targetSchema, collector)
-	generateCreateFunctionsSQL(functionsCallingNow, targetSchema, collector)
+	generateFunctionsAndAggregatesSQL(functionsNow, aggregatesNow, targetSchema, collector)
 	generateCreateViewsSQL(viewsLater, targetSchema, collector)
-	generateCreateFunctionsSQL(functionsLater, targetSchema, collector)
-	generateCreateAggregatesSQL(aggregatesLater, targetSchema, collector)
-	generateCreateFunctionsSQL(functionsCallingLater, targetSchema, collector)
+	generateFunctionsAndAggregatesSQL(functionsLater, aggregatesLater, targetSchema, collector)
+}
+
+// generateFunctionsAndAggregatesSQL creates functions and aggregates that may
+// depend on each other: an aggregate needs its support functions, and a
+// SQL-language function that calls an aggregate needs that aggregate. Each
+// round emits the functions that call none of the remaining aggregates, then
+// the aggregates whose support functions are all created, until nothing is
+// left. Anything that never becomes ready (a cycle PostgreSQL would reject
+// as well) is emitted as is so it still surfaces in the plan.
+func generateFunctionsAndAggregatesSQL(functions []*ir.Function, aggregates []*ir.Aggregate, targetSchema string, collector *diffCollector) {
+	for len(functions) > 0 || len(aggregates) > 0 {
+		functionsNow, functionsLater := splitFunctionsCallingAggregates(functions, aggregates)
+		aggregatesNow, aggregatesLater := splitAggregatesByViewDeps(aggregates, nil, buildFunctionLookup(functionsLater))
+		if len(functionsNow) == 0 && len(aggregatesNow) == 0 {
+			generateCreateFunctionsSQL(functions, targetSchema, collector)
+			generateCreateAggregatesSQL(aggregates, targetSchema, collector)
+			return
+		}
+		generateCreateFunctionsSQL(functionsNow, targetSchema, collector)
+		generateCreateAggregatesSQL(aggregatesNow, targetSchema, collector)
+		functions, aggregates = functionsLater, aggregatesLater
+	}
 }
 
 // splitViewsReferencingRoutines partitions views into those that can be created
@@ -3347,9 +3375,22 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 // INSERT INTO table, UPDATE [ONLY] table, DELETE FROM table, TABLE table.
 // Captures the table name (possibly schema-qualified) in group 1.
 var tableRefPattern = regexp.MustCompile(
-	`(?i)(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE)\s+(?:ONLY\s+)?` +
-		`((?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\s*\.\s*(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*)`,
+	`(?i)(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE)\s+` +
+		// A comma-separated list of relations, each "[ONLY] [(]name[)] [[AS] alias]";
+		// the alias is only consumed when a comma follows so keywords such as
+		// WHERE or JOIN after the last item are never taken for one.
+		`((?:` + relationRefExpr + `(?:\s+(?:AS\s+)?[a-z_][a-z0-9_$]*)?\s*,\s*)*` + relationRefExpr + `)`,
 )
+
+// relationRefExpr matches one relation in a FROM list: an optional ONLY, an
+// optionally parenthesized name, possibly quoted and possibly schema-qualified.
+const relationRefExpr = `(?:ONLY\s+)?\(?` + qualifiedIdentExpr + `\)?`
+
+// qualifiedIdentExpr matches a possibly quoted, possibly schema-qualified identifier.
+const qualifiedIdentExpr = `(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\s*\.\s*(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*`
+
+// leadingQualifiedIdent extracts the relation name at the start of one FROM-list item.
+var leadingQualifiedIdent = regexp.MustCompile(`(?i)^` + qualifiedIdentExpr)
 
 // normalizeRelationReference converts a relation reference captured by
 // tableRefPattern, possibly quoted and possibly schema-qualified, into the

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1977,6 +1977,12 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 		functionsWithViewDeps = deferRecreated(functionsWithViewDeps)
 	}
 
+	// SQL-language functions whose body calls a new aggregate are validated
+	// against it at creation, so they are created after the aggregates instead
+	// of in the table-relative batches below (#580).
+	var functionsCallingAggregates []*ir.Function
+	functionsWithoutViewDeps, functionsCallingAggregates = splitFunctionsCallingAggregates(functionsWithoutViewDeps, d.addedAggregates)
+
 	// Separate functions WITHOUT view deps into those that reference deferred
 	// tables and those that don't. Functions that query new tables must be
 	// created after those tables (issue #530). Functions referencing tables in
@@ -2065,6 +2071,9 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	aggregatesToCreateNow, d.aggregatesAwaitingRecreatedViews = splitAggregatesByViewDeps(d.addedAggregates, recreatedViewLookup, buildFunctionLookup(d.functionsAwaitingRecreatedViews))
 	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(aggregatesToCreateNow, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
 	generateCreateAggregatesSQL(aggregatesToCreateNow, targetSchema, collector)
+
+	// SQL-language functions that call one of the aggregates above.
+	generateCreateFunctionsSQL(functionsCallingAggregates, targetSchema, collector)
 
 	// Merge deferred policies from all batches
 	allDeferredPolicies := append(append(deferredPolicies1, deferredPolicies2...), deferredPolicies3...)
@@ -2761,6 +2770,45 @@ func splitFunctionsByViewDeps(functions []*ir.Function, views map[string]struct{
 	return now, later
 }
 
+// splitFunctionsCallingAggregates partitions functions into those that can be
+// created before the given aggregates and those whose SQL-language body calls
+// one of them, directly or through another such function. PostgreSQL resolves
+// a SQL body at creation, so the caller must follow the aggregate. Other
+// languages resolve calls at run time and are never held back. Order within
+// each partition is preserved.
+func splitFunctionsCallingAggregates(functions []*ir.Function, aggregates []*ir.Aggregate) (now, later []*ir.Function) {
+	if len(aggregates) == 0 {
+		return functions, nil
+	}
+	calls := func(fn *ir.Function, routines map[string]struct{}) bool {
+		return strings.EqualFold(fn.Language, "sql") && referencesNewFunction(fn.Definition, fn.Schema, routines)
+	}
+	aggregateLookup := buildRoutineLookup(nil, aggregates)
+	for _, fn := range functions {
+		if calls(fn, aggregateLookup) {
+			later = append(later, fn)
+		} else {
+			now = append(now, fn)
+		}
+	}
+	// Transitive closure: a function that calls a held-back function waits too.
+	for changed := len(later) > 0; changed; {
+		changed = false
+		lateLookup := buildFunctionLookup(later)
+		var still []*ir.Function
+		for _, fn := range now {
+			if calls(fn, lateLookup) {
+				later = append(later, fn)
+				changed = true
+			} else {
+				still = append(still, fn)
+			}
+		}
+		now = still
+	}
+	return now, later
+}
+
 // splitAggregatesByViewDeps partitions aggregates into those that can be
 // created now and those that depend on a view in the lookup, either through
 // their own argument, state, or return type or through a support function in
@@ -2789,13 +2837,19 @@ func generateViewsAndDependentRoutinesSQL(views []*ir.View, functions []*ir.Func
 	lateViewLookup := buildViewLookup(viewsLater)
 	functionsNow, functionsLater := splitFunctionsByViewDeps(functions, lateViewLookup)
 	aggregatesNow, aggregatesLater := splitAggregatesByViewDeps(aggregates, lateViewLookup, buildFunctionLookup(functionsLater))
+	// Within each half, SQL-language functions that call one of the aggregates
+	// go after it; the aggregates' own support functions stay ahead of them.
+	functionsNow, functionsCallingNow := splitFunctionsCallingAggregates(functionsNow, aggregatesNow)
+	functionsLater, functionsCallingLater := splitFunctionsCallingAggregates(functionsLater, aggregatesLater)
 
 	generateCreateViewsSQL(viewsNow, targetSchema, collector)
 	generateCreateFunctionsSQL(functionsNow, targetSchema, collector)
 	generateCreateAggregatesSQL(aggregatesNow, targetSchema, collector)
+	generateCreateFunctionsSQL(functionsCallingNow, targetSchema, collector)
 	generateCreateViewsSQL(viewsLater, targetSchema, collector)
 	generateCreateFunctionsSQL(functionsLater, targetSchema, collector)
 	generateCreateAggregatesSQL(aggregatesLater, targetSchema, collector)
+	generateCreateFunctionsSQL(functionsCallingLater, targetSchema, collector)
 }
 
 // splitViewsReferencingRoutines partitions views into those that can be created

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2074,12 +2074,28 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// creates it: callers of the aggregates created here stay here, the rest
 	// join the view-dependent or recreated-view batch of their aggregate. A
 	// view-dependent function calling a recreated-batch aggregate moves too.
-	var callersOfLateAggregates, callersOfRecreatedAggregates []*ir.Function
-	functionsCallingAggregates, callersOfLateAggregates = splitFunctionsCallingAggregates(functionsCallingAggregates, append(append([]*ir.Aggregate{}, aggregatesWithViewDeps...), d.aggregatesAwaitingRecreatedViews...))
-	callersOfLateAggregates, callersOfRecreatedAggregates = splitFunctionsCallingAggregates(callersOfLateAggregates, d.aggregatesAwaitingRecreatedViews)
-	functionsWithViewDeps = append(functionsWithViewDeps, callersOfLateAggregates...)
-	functionsWithViewDeps, callersOfLateAggregates = splitFunctionsCallingAggregates(functionsWithViewDeps, d.aggregatesAwaitingRecreatedViews)
-	d.functionsAwaitingRecreatedViews = append(append(d.functionsAwaitingRecreatedViews, callersOfRecreatedAggregates...), callersOfLateAggregates...)
+	// Moving a caller can in turn move an aggregate that uses it as a support
+	// function, and moving that aggregate can move its callers, so iterate
+	// until the batches are stable.
+	for changed := true; changed; {
+		changed = false
+		lateAggregates := append(append([]*ir.Aggregate{}, aggregatesWithViewDeps...), d.aggregatesAwaitingRecreatedViews...)
+
+		var moved, toRecreated []*ir.Function
+		functionsCallingAggregates, moved = splitFunctionsCallingAggregates(functionsCallingAggregates, lateAggregates)
+		functionsWithViewDeps = append(functionsWithViewDeps, moved...)
+		functionsWithViewDeps, toRecreated = splitFunctionsCallingAggregates(functionsWithViewDeps, d.aggregatesAwaitingRecreatedViews)
+		d.functionsAwaitingRecreatedViews = append(d.functionsAwaitingRecreatedViews, toRecreated...)
+		changed = changed || len(moved) > 0 || len(toRecreated) > 0
+
+		lateFunctions := buildFunctionLookup(append(append([]*ir.Function{}, functionsWithViewDeps...), d.functionsAwaitingRecreatedViews...))
+		var movedAggs, aggsToRecreated []*ir.Aggregate
+		aggregatesToCreateNow, movedAggs = splitAggregatesByViewDeps(aggregatesToCreateNow, nil, lateFunctions)
+		aggregatesWithViewDeps = append(aggregatesWithViewDeps, movedAggs...)
+		aggregatesWithViewDeps, aggsToRecreated = splitAggregatesByViewDeps(aggregatesWithViewDeps, nil, buildFunctionLookup(d.functionsAwaitingRecreatedViews))
+		d.aggregatesAwaitingRecreatedViews = append(d.aggregatesAwaitingRecreatedViews, aggsToRecreated...)
+		changed = changed || len(movedAggs) > 0 || len(aggsToRecreated) > 0
+	}
 
 	// Aggregates and their callers may chain (aggregate a -> SQL support
 	// function calling a -> aggregate b), so they are scheduled together.
@@ -2711,26 +2727,12 @@ func functionReferencesNewView(fn *ir.Function, newViews map[string]struct{}) bo
 	return bodyReferencesRelation(fn.Definition, newViews)
 }
 
-// bodyReferencesRelation scans a function body for FROM/JOIN/INTO/UPDATE/TABLE
-// references to a relation in the lookup.
+// bodyReferencesRelation reports whether a function body references a relation
+// in the lookup in relation position (see relationReferences).
 func bodyReferencesRelation(body string, relations map[string]struct{}) bool {
-	for _, match := range tableRefPattern.FindAllStringSubmatch(body, -1) {
-		if len(match) < 2 {
-			continue
-		}
-		for _, item := range splitTopLevelCommas(match[1]) {
-			item = strings.TrimSpace(item)
-			if len(item) > 5 && strings.EqualFold(item[:5], "ONLY ") {
-				item = strings.TrimSpace(item[5:])
-			}
-			item = strings.TrimPrefix(item, "(")
-			name := leadingQualifiedIdent.FindString(item)
-			if name == "" {
-				continue
-			}
-			if _, ok := relations[normalizeRelationReference(name)]; ok {
-				return true
-			}
+	for _, name := range relationReferences(body) {
+		if _, ok := relations[normalizeRelationReference(name)]; ok {
+			return true
 		}
 	}
 	return false
@@ -3005,13 +3007,30 @@ func tableReturnColumnTypes(returnType string) []string {
 func stripLeadingIdentifier(decl string) string {
 	var rest string
 	if strings.HasPrefix(decl, `"`) {
-		if end := strings.Index(decl[1:], `"`); end >= 0 {
-			rest = decl[end+2:]
+		if end := quotedIdentEnd(decl, 0); end > 0 {
+			rest = decl[end:]
 		}
 	} else if idx := strings.IndexByte(decl, ' '); idx >= 0 {
 		rest = decl[idx+1:]
 	}
 	return strings.TrimSpace(rest)
+}
+
+// quotedIdentEnd returns the index just past the quoted identifier starting at
+// s[start] (which must be a double quote), honoring "" escapes, or -1 if the
+// identifier is unterminated.
+func quotedIdentEnd(s string, start int) int {
+	for i := start + 1; i < len(s); i++ {
+		if s[i] != '"' {
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == '"' {
+			i++
+			continue
+		}
+		return i + 1
+	}
+	return -1
 }
 
 // findUnquotedOrderBy returns the index of the "ORDER BY " separator that
@@ -3374,23 +3393,138 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 // tableRefPattern matches SQL table references: FROM table, JOIN table,
 // INSERT INTO table, UPDATE [ONLY] table, DELETE FROM table, TABLE table.
 // Captures the table name (possibly schema-qualified) in group 1.
-var tableRefPattern = regexp.MustCompile(
-	`(?i)(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE)\s+` +
-		// A comma-separated list of relations, each "[ONLY] [(]name[)] [[AS] alias]";
-		// the alias is only consumed when a comma follows so keywords such as
-		// WHERE or JOIN after the last item are never taken for one.
-		`((?:` + relationRefExpr + `(?:\s+(?:AS\s+)?[a-z_][a-z0-9_$]*)?\s*,\s*)*` + relationRefExpr + `)`,
-)
-
-// relationRefExpr matches one relation in a FROM list: an optional ONLY, an
-// optionally parenthesized name, possibly quoted and possibly schema-qualified.
-const relationRefExpr = `(?:ONLY\s+)?\(?` + qualifiedIdentExpr + `\)?`
+// relationKeywordPattern finds the keywords that introduce a relation or a
+// relation list: FROM, JOIN, INTO, UPDATE, DELETE FROM, TABLE.
+var relationKeywordPattern = regexp.MustCompile(`(?i)\b(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE)\s+`)
 
 // qualifiedIdentExpr matches a possibly quoted, possibly schema-qualified identifier.
 const qualifiedIdentExpr = `(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\s*\.\s*(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*`
 
-// leadingQualifiedIdent extracts the relation name at the start of one FROM-list item.
+// leadingQualifiedIdent extracts the identifier at the start of a string.
 var leadingQualifiedIdent = regexp.MustCompile(`(?i)^` + qualifiedIdentExpr)
+
+// relationReferences returns the relation names a SQL body references in
+// relation position: after FROM, JOIN, INTO, UPDATE, DELETE FROM, or TABLE,
+// walking a comma-separated list of table references. Function calls and
+// subqueries are skipped, ONLY and the parenthesized ONLY (name) form are
+// accepted, and an alias with an optional column list is consumed only when
+// another list item follows it, so a keyword after the last item is never
+// mistaken for an alias. This is a heuristic scan, not a parser: a string
+// literal or comment that mimics a FROM clause is scanned like real SQL.
+func relationReferences(body string) []string {
+	var refs []string
+	for _, loc := range relationKeywordPattern.FindAllStringIndex(body, -1) {
+		// After INTO the next token is always a relation, so "t(a, b)" is a
+		// column list, not a function call.
+		callAllowed := !strings.Contains(strings.ToUpper(body[loc[0]:loc[1]]), "INTO")
+		i := loc[1]
+		for {
+			i = skipSpaces(body, i)
+			if keywordAt(body, i, "ONLY") {
+				i = skipSpaces(body, i+len("ONLY"))
+			}
+			if i < len(body) && body[i] == '(' {
+				// Either "(name)" or a subquery; only the former is a relation.
+				end := matchingParen(body, i)
+				inner := strings.TrimSpace(body[i+1 : end])
+				if name := leadingQualifiedIdent.FindString(inner); name != "" && name == inner {
+					refs = append(refs, name)
+				}
+				i = end + 1
+			} else {
+				name := leadingQualifiedIdent.FindString(body[i:])
+				if name == "" {
+					break
+				}
+				i += len(name)
+				if callAllowed && i < len(body) && body[i] == '(' {
+					i = matchingParen(body, i) + 1 // function call, not a relation
+				} else {
+					refs = append(refs, name)
+				}
+			}
+
+			// Another item follows directly, or after "[AS] alias [(columns)]".
+			next := skipSpaces(body, i)
+			if next < len(body) && body[next] == ',' {
+				i = next + 1
+				continue
+			}
+			if keywordAt(body, next, "AS") {
+				next = skipSpaces(body, next+len("AS"))
+			}
+			alias := leadingQualifiedIdent.FindString(body[next:])
+			if alias == "" || strings.Contains(alias, ".") {
+				break
+			}
+			next = skipSpaces(body, next+len(alias))
+			if next < len(body) && body[next] == '(' {
+				next = skipSpaces(body, matchingParen(body, next)+1)
+			}
+			if next < len(body) && body[next] == ',' {
+				i = next + 1
+				continue
+			}
+			break
+		}
+	}
+	return refs
+}
+
+// skipSpaces returns the index of the first non-whitespace byte at or after i.
+func skipSpaces(s string, i int) int {
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
+		i++
+	}
+	return i
+}
+
+// keywordAt reports whether the keyword occurs at s[i] as a whole word,
+// case-insensitively.
+func keywordAt(s string, i int, keyword string) bool {
+	end := i + len(keyword)
+	if i < 0 || end > len(s) || !strings.EqualFold(s[i:end], keyword) {
+		return false
+	}
+	return end == len(s) || !isIdentByte(s[end])
+}
+
+// isIdentByte reports whether b can appear in a bare SQL identifier.
+func isIdentByte(b byte) bool {
+	return b == '_' || b == '$' || (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// matchingParen returns the index of the parenthesis closing the one at s[i],
+// skipping quoted identifiers and string literals, or len(s)-1 if unbalanced.
+func matchingParen(s string, i int) int {
+	depth := 0
+	for j := i; j < len(s); j++ {
+		switch s[j] {
+		case '"':
+			if end := quotedIdentEnd(s, j); end > 0 {
+				j = end - 1
+			}
+		case '\'':
+			for j++; j < len(s); j++ {
+				if s[j] == '\'' {
+					if j+1 < len(s) && s[j+1] == '\'' {
+						j++
+						continue
+					}
+					break
+				}
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return j
+			}
+		}
+	}
+	return len(s) - 1
+}
 
 // normalizeRelationReference converts a relation reference captured by
 // tableRefPattern, possibly quoted and possibly schema-qualified, into the

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2072,30 +2072,12 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(aggregatesToCreateNow, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
 	// SQL-language functions that call an aggregate follow the batch that
 	// creates it: callers of the aggregates created here stay here, the rest
-	// join the view-dependent or recreated-view batch of their aggregate. A
-	// view-dependent function calling a recreated-batch aggregate moves too.
-	// Moving a caller can in turn move an aggregate that uses it as a support
-	// function, and moving that aggregate can move its callers, so iterate
-	// until the batches are stable.
-	for changed := true; changed; {
-		changed = false
-		lateAggregates := append(append([]*ir.Aggregate{}, aggregatesWithViewDeps...), d.aggregatesAwaitingRecreatedViews...)
-
-		var moved, toRecreated []*ir.Function
-		functionsCallingAggregates, moved = splitFunctionsCallingAggregates(functionsCallingAggregates, lateAggregates)
-		functionsWithViewDeps = append(functionsWithViewDeps, moved...)
-		functionsWithViewDeps, toRecreated = splitFunctionsCallingAggregates(functionsWithViewDeps, d.aggregatesAwaitingRecreatedViews)
-		d.functionsAwaitingRecreatedViews = append(d.functionsAwaitingRecreatedViews, toRecreated...)
-		changed = changed || len(moved) > 0 || len(toRecreated) > 0
-
-		lateFunctions := buildFunctionLookup(append(append([]*ir.Function{}, functionsWithViewDeps...), d.functionsAwaitingRecreatedViews...))
-		var movedAggs, aggsToRecreated []*ir.Aggregate
-		aggregatesToCreateNow, movedAggs = splitAggregatesByViewDeps(aggregatesToCreateNow, nil, lateFunctions)
-		aggregatesWithViewDeps = append(aggregatesWithViewDeps, movedAggs...)
-		aggregatesWithViewDeps, aggsToRecreated = splitAggregatesByViewDeps(aggregatesWithViewDeps, nil, buildFunctionLookup(d.functionsAwaitingRecreatedViews))
-		d.aggregatesAwaitingRecreatedViews = append(d.aggregatesAwaitingRecreatedViews, aggsToRecreated...)
-		changed = changed || len(movedAggs) > 0 || len(aggsToRecreated) > 0
-	}
+	// join the view-dependent or recreated-view batch of their aggregate.
+	var callersOfLateAggregates, callersOfRecreatedAggregates []*ir.Function
+	functionsCallingAggregates, callersOfLateAggregates = splitFunctionsCallingAggregates(functionsCallingAggregates, append(append([]*ir.Aggregate{}, aggregatesWithViewDeps...), d.aggregatesAwaitingRecreatedViews...))
+	callersOfLateAggregates, callersOfRecreatedAggregates = splitFunctionsCallingAggregates(callersOfLateAggregates, d.aggregatesAwaitingRecreatedViews)
+	functionsWithViewDeps = append(functionsWithViewDeps, callersOfLateAggregates...)
+	d.functionsAwaitingRecreatedViews = append(d.functionsAwaitingRecreatedViews, callersOfRecreatedAggregates...)
 
 	// Aggregates and their callers may chain (aggregate a -> SQL support
 	// function calling a -> aggregate b), so they are scheduled together.
@@ -2161,13 +2143,7 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 
 	// A new view that calls a routine held for a view recreation must wait for
 	// that routine too; it is created in the modify phase with that batch (#480).
-	recreatedRoutineLookup := buildRoutineLookup(d.functionsAwaitingRecreatedViews, d.aggregatesAwaitingRecreatedViews)
-	viewsToCreateNow, d.viewsAwaitingRecreatedViews = splitViewsReferencingRoutines(viewsToCreateNow, recreatedRoutineLookup)
-	// The same applies to views deferred for an added column (issue #414): the
-	// recreated-view batch runs after the column is added, so they can join it.
-	var deferredCallingRecreated []*ir.View
-	d.deferredAddedViews, deferredCallingRecreated = splitViewsReferencingRoutines(d.deferredAddedViews, recreatedRoutineLookup)
-	d.viewsAwaitingRecreatedViews = append(d.viewsAwaitingRecreatedViews, deferredCallingRecreated...)
+	viewsToCreateNow, d.viewsAwaitingRecreatedViews = splitViewsReferencingRoutines(viewsToCreateNow, buildRoutineLookup(d.functionsAwaitingRecreatedViews, d.aggregatesAwaitingRecreatedViews))
 
 	// Create views, then the functions and aggregates that reference views in
 	// their signature or SQL body (issue #300, #580).

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -323,6 +323,7 @@ type ddlDiff struct {
 	// recreates the view (issue #480).
 	functionsAwaitingRecreatedViews  []*ir.Function
 	aggregatesAwaitingRecreatedViews []*ir.Aggregate
+	viewsAwaitingRecreatedViews      []*ir.View
 	// Foreign keys that depend on a unique/PK constraint being dropped or
 	// recreated by this migration: existing ones are dropped before the table
 	// modifications (fkPreDrops) and desired-state ones are (re)created
@@ -2056,10 +2057,13 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// Aggregates that depend on a new view, either through their own argument,
 	// state, or return type, or through a support function that does, are held
 	// back until the view and the view-dependent functions exist (#580).
-	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(d.addedAggregates, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
 	// Aggregates typed on a view being recreated, or built on a function that is,
 	// wait for the recreation in the modify phase, like those functions (issue #480).
-	aggregatesToCreateNow, d.aggregatesAwaitingRecreatedViews = splitAggregatesByViewDeps(aggregatesToCreateNow, recreatedViewLookup, buildFunctionLookup(d.functionsAwaitingRecreatedViews))
+	// This split comes first so an aggregate that also depends on a new view is
+	// still held for the recreation, which happens after the whole create phase.
+	var aggregatesToCreateNow []*ir.Aggregate
+	aggregatesToCreateNow, d.aggregatesAwaitingRecreatedViews = splitAggregatesByViewDeps(d.addedAggregates, recreatedViewLookup, buildFunctionLookup(d.functionsAwaitingRecreatedViews))
+	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(aggregatesToCreateNow, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
 	generateCreateAggregatesSQL(aggregatesToCreateNow, targetSchema, collector)
 
 	// Merge deferred policies from all batches
@@ -2119,6 +2123,10 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 		functionsWithViewDeps, d.functionsAwaitingDeferredViews = splitFunctionsByViewDeps(functionsWithViewDeps, deferredViewLookup)
 		aggregatesWithViewDeps, d.aggregatesAwaitingDeferredViews = splitAggregatesByViewDeps(aggregatesWithViewDeps, deferredViewLookup, buildFunctionLookup(d.functionsAwaitingDeferredViews))
 	}
+
+	// A new view that calls a routine held for a view recreation must wait for
+	// that routine too; it is created in the modify phase with that batch (#480).
+	viewsToCreateNow, d.viewsAwaitingRecreatedViews = splitViewsReferencingRoutines(viewsToCreateNow, buildRoutineLookup(d.functionsAwaitingRecreatedViews, d.aggregatesAwaitingRecreatedViews))
 
 	// Create views, then the functions and aggregates that reference views in
 	// their signature or SQL body (issue #300, #580).
@@ -2197,9 +2205,9 @@ func (d *ddlDiff) generateModifySQL(targetSchema string, collector *diffCollecto
 	// type references a view just recreated above. Emitting them now (rather than in
 	// the create phase) keeps the recreated view free of dependents during its
 	// RESTRICT drop (issue #480).
-	// Aggregates built on those functions, or typed on the recreated view, follow.
-	generateCreateFunctionsSQL(d.functionsAwaitingRecreatedViews, targetSchema, collector)
-	generateCreateAggregatesSQL(d.aggregatesAwaitingRecreatedViews, targetSchema, collector)
+	// Aggregates built on those functions, or typed on the recreated view, and
+	// new views that call any of these routines, follow in dependency order.
+	generateViewsAndDependentRoutinesSQL(d.viewsAwaitingRecreatedViews, d.functionsAwaitingRecreatedViews, d.aggregatesAwaitingRecreatedViews, targetSchema, collector)
 
 	// Modify functions
 	generateModifyFunctionsSQL(d.modifiedFunctions, targetSchema, collector)
@@ -2699,7 +2707,7 @@ func aggregateReferencesNewView(agg *ir.Aggregate, newViews map[string]struct{})
 	if agg == nil || len(newViews) == 0 {
 		return false
 	}
-	candidates := append([]string{agg.StateType, agg.MStateType, agg.ReturnType}, splitTopLevelCommas(agg.Arguments)...)
+	candidates := append([]string{agg.StateType, agg.MStateType, agg.ReturnType}, aggregateArgumentTypes(agg.Arguments)...)
 	for _, typ := range candidates {
 		if typeMatchesLookup(extractBaseTypeName(typ), agg.Schema, newViews) {
 			return true
@@ -2886,25 +2894,55 @@ func tableReturnColumnTypes(returnType string) []string {
 	inner := t[6 : len(t)-1]
 
 	var types []string
-	appendColType := func(col string) {
-		col = strings.TrimSpace(col)
-		// Strip the leading column name (possibly a quoted identifier
-		// containing spaces) to leave the type expression.
-		var typeExpr string
-		if strings.HasPrefix(col, `"`) {
-			if end := strings.Index(col[1:], `"`); end >= 0 {
-				typeExpr = col[end+2:]
-			}
-		} else if idx := strings.IndexByte(col, ' '); idx >= 0 {
-			typeExpr = col[idx+1:]
-		}
-		if typeExpr = strings.TrimSpace(typeExpr); typeExpr != "" {
+	for _, col := range splitTopLevelCommas(inner) {
+		// Each column is "name type"; drop the name to leave the type expression.
+		if typeExpr := stripLeadingIdentifier(strings.TrimSpace(col)); typeExpr != "" {
 			types = append(types, typeExpr)
 		}
 	}
+	return types
+}
 
-	for _, col := range splitTopLevelCommas(inner) {
-		appendColType(col)
+// stripLeadingIdentifier removes a leading identifier (bare, or quoted and
+// possibly containing spaces) from a declaration such as `name type` or
+// `"my col" numeric(10,2)` and returns the remainder, trimmed. It returns ""
+// when the declaration has no second part.
+func stripLeadingIdentifier(decl string) string {
+	var rest string
+	if strings.HasPrefix(decl, `"`) {
+		if end := strings.Index(decl[1:], `"`); end >= 0 {
+			rest = decl[end+2:]
+		}
+	} else if idx := strings.IndexByte(decl, ' '); idx >= 0 {
+		rest = decl[idx+1:]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// aggregateArgumentTypes extracts candidate type expressions from an
+// aggregate's identity argument list, which may carry argument names, a
+// VARIADIC marker, and the ORDER BY separator of ordered-set aggregates
+// (e.g. "r v", "ORDER BY v", "x integer ORDER BY v"). Each argument yields
+// both its whole declaration and the part after a leading name, so the type
+// is found whether or not the argument is named.
+func aggregateArgumentTypes(args string) []string {
+	var types []string
+	for _, arg := range splitTopLevelCommas(args) {
+		arg = strings.TrimSpace(arg)
+		if idx := strings.Index(strings.ToUpper(arg), "ORDER BY "); idx >= 0 {
+			types = append(types, aggregateArgumentTypes(arg[:idx])...)
+			arg = strings.TrimSpace(arg[idx+len("ORDER BY "):])
+		}
+		if len(arg) > 9 && strings.EqualFold(arg[:9], "VARIADIC ") {
+			arg = strings.TrimSpace(arg[9:])
+		}
+		if arg == "" {
+			continue
+		}
+		types = append(types, arg)
+		if rest := stripLeadingIdentifier(arg); rest != "" {
+			types = append(types, rest)
+		}
 	}
 	return types
 }
@@ -3220,7 +3258,7 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 // INSERT INTO table, UPDATE [ONLY] table, DELETE FROM table, TABLE table.
 // Captures the table name (possibly schema-qualified) in group 1.
 var tableRefPattern = regexp.MustCompile(
-	`(?i)(?:FROM|JOIN|INTO|UPDATE(?:\s+ONLY)?|DELETE\s+FROM|TABLE)\s+` +
+	`(?i)(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE)\s+(?:ONLY\s+)?` +
 		`((?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\.(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*)`,
 )
 

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2072,7 +2072,14 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(aggregatesToCreateNow, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
 	generateCreateAggregatesSQL(aggregatesToCreateNow, targetSchema, collector)
 
-	// SQL-language functions that call one of the aggregates above.
+	// SQL-language functions that call an aggregate follow the batch that
+	// creates it: those calling only the aggregates above are created here, the
+	// rest join the view-dependent or recreated-view batch of their aggregate.
+	var callersOfLateAggregates, callersOfRecreatedAggregates []*ir.Function
+	functionsCallingAggregates, callersOfLateAggregates = splitFunctionsCallingAggregates(functionsCallingAggregates, append(append([]*ir.Aggregate{}, aggregatesWithViewDeps...), d.aggregatesAwaitingRecreatedViews...))
+	callersOfLateAggregates, callersOfRecreatedAggregates = splitFunctionsCallingAggregates(callersOfLateAggregates, d.aggregatesAwaitingRecreatedViews)
+	functionsWithViewDeps = append(functionsWithViewDeps, callersOfLateAggregates...)
+	d.functionsAwaitingRecreatedViews = append(d.functionsAwaitingRecreatedViews, callersOfRecreatedAggregates...)
 	generateCreateFunctionsSQL(functionsCallingAggregates, targetSchema, collector)
 
 	// Merge deferred policies from all batches
@@ -2135,7 +2142,13 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 
 	// A new view that calls a routine held for a view recreation must wait for
 	// that routine too; it is created in the modify phase with that batch (#480).
-	viewsToCreateNow, d.viewsAwaitingRecreatedViews = splitViewsReferencingRoutines(viewsToCreateNow, buildRoutineLookup(d.functionsAwaitingRecreatedViews, d.aggregatesAwaitingRecreatedViews))
+	recreatedRoutineLookup := buildRoutineLookup(d.functionsAwaitingRecreatedViews, d.aggregatesAwaitingRecreatedViews)
+	viewsToCreateNow, d.viewsAwaitingRecreatedViews = splitViewsReferencingRoutines(viewsToCreateNow, recreatedRoutineLookup)
+	// The same applies to views deferred for an added column (issue #414): the
+	// recreated-view batch runs after the column is added, so they can join it.
+	var deferredCallingRecreated []*ir.View
+	d.deferredAddedViews, deferredCallingRecreated = splitViewsReferencingRoutines(d.deferredAddedViews, recreatedRoutineLookup)
+	d.viewsAwaitingRecreatedViews = append(d.viewsAwaitingRecreatedViews, deferredCallingRecreated...)
 
 	// Create views, then the functions and aggregates that reference views in
 	// their signature or SQL body (issue #300, #580).
@@ -2973,6 +2986,28 @@ func stripLeadingIdentifier(decl string) string {
 	return strings.TrimSpace(rest)
 }
 
+// findUnquotedOrderBy returns the index of the "ORDER BY " separator that
+// pg_get_function_identity_arguments emits for ordered-set aggregates, or -1.
+// The match is case-insensitive, must start a token, and is ignored inside a
+// quoted identifier such as "Order By V".
+func findUnquotedOrderBy(s string) int {
+	const sep = "ORDER BY "
+	inQuote := false
+	for i := 0; i+len(sep) <= len(s); i++ {
+		if s[i] == '"' {
+			inQuote = !inQuote
+			continue
+		}
+		if inQuote || (i > 0 && s[i-1] != ' ') {
+			continue
+		}
+		if strings.EqualFold(s[i:i+len(sep)], sep) {
+			return i
+		}
+	}
+	return -1
+}
+
 // aggregateArgumentTypes extracts candidate type expressions from an
 // aggregate's identity argument list, which may carry argument names, a
 // VARIADIC marker, and the ORDER BY separator of ordered-set aggregates
@@ -2983,7 +3018,7 @@ func aggregateArgumentTypes(args string) []string {
 	var types []string
 	for _, arg := range splitTopLevelCommas(args) {
 		arg = strings.TrimSpace(arg)
-		if idx := strings.Index(strings.ToUpper(arg), "ORDER BY "); idx >= 0 {
+		if idx := findUnquotedOrderBy(arg); idx >= 0 {
 			types = append(types, aggregateArgumentTypes(arg[:idx])...)
 			arg = strings.TrimSpace(arg[idx+len("ORDER BY "):])
 		}
@@ -3313,7 +3348,7 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 // Captures the table name (possibly schema-qualified) in group 1.
 var tableRefPattern = regexp.MustCompile(
 	`(?i)(?:FROM|JOIN|INTO|UPDATE|DELETE\s+FROM|TABLE)\s+(?:ONLY\s+)?` +
-		`((?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\.(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*)`,
+		`((?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\s*\.\s*(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*)`,
 )
 
 // normalizeRelationReference converts a relation reference captured by
@@ -3321,9 +3356,9 @@ var tableRefPattern = regexp.MustCompile(
 // lowercase "name" or "schema.name" key format of buildSchemaNameLookup.
 func normalizeRelationReference(raw string) string {
 	if idx := findLastUnquotedDot(raw); idx != -1 {
-		return strings.ToLower(unquoteIdent(raw[:idx]) + "." + unquoteIdent(raw[idx+1:]))
+		return strings.ToLower(unquoteIdent(strings.TrimSpace(raw[:idx])) + "." + unquoteIdent(strings.TrimSpace(raw[idx+1:])))
 	}
-	return strings.ToLower(unquoteIdent(raw))
+	return strings.ToLower(unquoteIdent(strings.TrimSpace(raw)))
 }
 
 // functionReferencesNewTable determines if a function references any newly

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -2052,20 +2052,10 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// Create aggregates after their transition/final functions AND all tables exist
 	// (an aggregate may use a new table's row type as an argument or state type), and
 	// before views, which may reference the aggregates in their definitions.
-	// Aggregates whose argument, state, or return type is a new view's row type
-	// are held back until the view and the view-dependent functions exist (#580).
-	aggregatesToCreateNow := d.addedAggregates
-	var aggregatesWithViewDeps []*ir.Aggregate
-	if len(newViewLookup) > 0 {
-		aggregatesToCreateNow = nil
-		for _, agg := range d.addedAggregates {
-			if aggregateReferencesNewView(agg, newViewLookup) {
-				aggregatesWithViewDeps = append(aggregatesWithViewDeps, agg)
-			} else {
-				aggregatesToCreateNow = append(aggregatesToCreateNow, agg)
-			}
-		}
-	}
+	// Aggregates that depend on a new view, either through their own argument,
+	// state, or return type, or through a support function that does, are held
+	// back until the view and the view-dependent functions exist (#580).
+	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(d.addedAggregates, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
 	generateCreateAggregatesSQL(aggregatesToCreateNow, targetSchema, collector)
 
 	// Merge deferred policies from all batches
@@ -2117,40 +2107,38 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 			}
 		}
 	}
+	// A view that calls a view-dependent function or aggregate must wait for that
+	// routine, which itself waits for the views it depends on. Hold such views,
+	// and any view built on them, until after the late routines exist (#580).
+	viewsToCreateNow, viewsAfterLateRoutines := splitViewsReferencingRoutines(viewsToCreateNow, buildRoutineLookup(functionsWithViewDeps, aggregatesWithViewDeps))
 	generateCreateViewsSQL(viewsToCreateNow, targetSchema, collector)
 
 	// If any views were deferred, also defer functions whose view dependency is
-	// on those deferred views — they must be created after the views exist.
+	// on those deferred views, and aggregates built on such functions — they
+	// must be created after the views exist.
 	if len(d.deferredAddedViews) > 0 {
 		deferredViewLookup := buildViewLookup(d.deferredAddedViews)
-		var keepNow []*ir.Function
-		for _, fn := range functionsWithViewDeps {
-			if functionReferencesNewView(fn, deferredViewLookup) {
-				d.functionsAwaitingDeferredViews = append(d.functionsAwaitingDeferredViews, fn)
-			} else {
-				keepNow = append(keepNow, fn)
-			}
-		}
-		functionsWithViewDeps = keepNow
-
-		var keepAggs []*ir.Aggregate
-		for _, agg := range aggregatesWithViewDeps {
-			if aggregateReferencesNewView(agg, deferredViewLookup) {
-				d.aggregatesAwaitingDeferredViews = append(d.aggregatesAwaitingDeferredViews, agg)
-			} else {
-				keepAggs = append(keepAggs, agg)
-			}
-		}
-		aggregatesWithViewDeps = keepAggs
+		functionsWithViewDeps, d.functionsAwaitingDeferredViews = splitFunctionsByViewDeps(functionsWithViewDeps, deferredViewLookup)
+		aggregatesWithViewDeps, d.aggregatesAwaitingDeferredViews = splitAggregatesByViewDeps(aggregatesWithViewDeps, deferredViewLookup, buildFunctionLookup(d.functionsAwaitingDeferredViews))
 	}
 
 	// Create functions WITH view dependencies (now that views exist)
 	// These functions reference views in their return type or parameter types (issue #300)
+	// Functions that depend on a held-back view, and aggregates built on them,
+	// are emitted after that view further below.
+	lateViewLookup := buildViewLookup(viewsAfterLateRoutines)
+	functionsWithViewDeps, functionsAfterLateViews := splitFunctionsByViewDeps(functionsWithViewDeps, lateViewLookup)
+	aggregatesWithViewDeps, aggregatesAfterLateViews := splitAggregatesByViewDeps(aggregatesWithViewDeps, lateViewLookup, buildFunctionLookup(functionsAfterLateViews))
 	generateCreateFunctionsSQL(functionsWithViewDeps, targetSchema, collector)
 
-	// Create aggregates that use a new view's row type, after the view and after
-	// any transition/final function that takes the row type as well (#580).
+	// Create aggregates that depend on a new view, after the view and after any
+	// support function that depends on it as well (#580).
 	generateCreateAggregatesSQL(aggregatesWithViewDeps, targetSchema, collector)
+
+	// Views that call the routines above, then the routines that depend on those views.
+	generateCreateViewsSQL(viewsAfterLateRoutines, targetSchema, collector)
+	generateCreateFunctionsSQL(functionsAfterLateViews, targetSchema, collector)
+	generateCreateAggregatesSQL(aggregatesAfterLateViews, targetSchema, collector)
 
 	// Revoke default grants on new tables that the user explicitly didn't include
 	// This must happen AFTER tables are created but BEFORE explicit grants
@@ -2620,21 +2608,33 @@ func buildSchemaNameLookup(names []struct{ schema, name string }) map[string]str
 // (mixed case, reserved word, special characters) keeps its exact case here,
 // matching functionLookupKeyPart used when normalizing scanned expressions.
 func buildFunctionLookup(functions []*ir.Function) map[string]struct{} {
-	if len(functions) == 0 {
+	return buildRoutineLookup(functions, nil)
+}
+
+// buildRoutineLookup returns lookup keys for newly added functions and
+// aggregates, which share call syntax, for use with referencesNewFunction.
+// Case folding follows the rules described on buildFunctionLookup.
+func buildRoutineLookup(functions []*ir.Function, aggregates []*ir.Aggregate) map[string]struct{} {
+	if len(functions) == 0 && len(aggregates) == 0 {
 		return nil
 	}
 
-	lookup := make(map[string]struct{}, len(functions)*2)
+	lookup := make(map[string]struct{}, 2*(len(functions)+len(aggregates)))
+	add := func(schema, name string) {
+		key := functionLookupKeyPart(name)
+		if key == "" {
+			return
+		}
+		lookup[key] = struct{}{}
+		if schema != "" {
+			lookup[functionGraphKey(schema, name)] = struct{}{}
+		}
+	}
 	for _, fn := range functions {
-		name := functionLookupKeyPart(fn.Name)
-		if name == "" {
-			continue
-		}
-		lookup[name] = struct{}{}
-
-		if fn.Schema != "" {
-			lookup[functionGraphKey(fn.Schema, fn.Name)] = struct{}{}
-		}
+		add(fn.Schema, fn.Name)
+	}
+	for _, agg := range aggregates {
+		add(agg.Schema, agg.Name)
 	}
 	return lookup
 }
@@ -2723,13 +2723,95 @@ func aggregateReferencesNewView(agg *ir.Aggregate, newViews map[string]struct{})
 	if agg == nil || len(newViews) == 0 {
 		return false
 	}
-	candidates := append([]string{agg.StateType, agg.MStateType, agg.ReturnType}, strings.Split(agg.Arguments, ",")...)
+	candidates := append([]string{agg.StateType, agg.MStateType, agg.ReturnType}, splitTopLevelCommas(agg.Arguments)...)
 	for _, typ := range candidates {
 		if typeMatchesLookup(extractBaseTypeName(typ), agg.Schema, newViews) {
 			return true
 		}
 	}
 	return false
+}
+
+// aggregateUsesFunction reports whether any of the aggregate's support functions
+// (transition, final, combine, serial/deserial, and their moving-aggregate
+// variants) is in a lookup built by buildFunctionLookup.
+func aggregateUsesFunction(agg *ir.Aggregate, functions map[string]struct{}) bool {
+	if agg == nil || len(functions) == 0 {
+		return false
+	}
+	for _, name := range []string{
+		agg.TransitionFunction, agg.FinalFunction, agg.CombineFunction,
+		agg.SerialFunction, agg.DeserialFunction,
+		agg.MTransitionFunction, agg.MInvTransitionFunction, agg.MFinalFunction,
+	} {
+		if name == "" {
+			continue
+		}
+		identifier := normalizeFunctionIdentifier(name)
+		if _, ok := functions[identifier]; ok {
+			return true
+		}
+		if !strings.Contains(identifier, "\x00") && agg.Schema != "" {
+			if _, ok := functions[functionGraphKey(agg.Schema, identifier)]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// splitFunctionsByViewDeps partitions functions into those that can be created
+// now and those whose signature or SQL body references a view in the lookup.
+// Order within each partition is preserved.
+func splitFunctionsByViewDeps(functions []*ir.Function, views map[string]struct{}) (now, later []*ir.Function) {
+	if len(views) == 0 {
+		return functions, nil
+	}
+	for _, fn := range functions {
+		if functionReferencesNewView(fn, views) {
+			later = append(later, fn)
+		} else {
+			now = append(now, fn)
+		}
+	}
+	return now, later
+}
+
+// splitAggregatesByViewDeps partitions aggregates into those that can be
+// created now and those that depend on a view in the lookup, either through
+// their own argument, state, or return type or through a support function in
+// the functions lookup (one that itself depends on such a view). Order within
+// each partition is preserved.
+func splitAggregatesByViewDeps(aggregates []*ir.Aggregate, views, functions map[string]struct{}) (now, later []*ir.Aggregate) {
+	if len(views) == 0 && len(functions) == 0 {
+		return aggregates, nil
+	}
+	for _, agg := range aggregates {
+		if aggregateReferencesNewView(agg, views) || aggregateUsesFunction(agg, functions) {
+			later = append(later, agg)
+		} else {
+			now = append(now, agg)
+		}
+	}
+	return now, later
+}
+
+// splitViewsReferencingRoutines partitions views into those that can be created
+// now and those that call a routine in the lookup, directly or through another
+// held-back view. The input is topologically sorted, so a single pass suffices:
+// a view built on a held-back view appears after it and sees it in `later`.
+func splitViewsReferencingRoutines(views []*ir.View, routines map[string]struct{}) (now, later []*ir.View) {
+	if len(routines) == 0 {
+		return views, nil
+	}
+	for _, v := range views {
+		if referencesNewFunction(v.Definition, v.Schema, routines) || viewReferencesAnyDeferredView(v, later) {
+			later = append(later, v)
+		} else {
+			now = append(now, v)
+		}
+	}
+	return now, later
 }
 
 // RelationLookup builds a case-insensitive lookup of table and view names, keyed
@@ -2827,12 +2909,20 @@ func tableReturnColumnTypes(returnType string) []string {
 		}
 	}
 
-	// Split on top-level commas, ignoring commas inside parentheses (e.g.
-	// numeric(10,2)) and quoted identifiers.
+	for _, col := range splitTopLevelCommas(inner) {
+		appendColType(col)
+	}
+	return types
+}
+
+// splitTopLevelCommas splits s on commas that are not inside parentheses (e.g.
+// numeric(10,2)) or quoted identifiers.
+func splitTopLevelCommas(s string) []string {
+	var parts []string
 	depth, start := 0, 0
 	inQuote := false
-	for i := 0; i < len(inner); i++ {
-		switch inner[i] {
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
 		case '"':
 			inQuote = !inQuote
 		case '(':
@@ -2845,13 +2935,12 @@ func tableReturnColumnTypes(returnType string) []string {
 			}
 		case ',':
 			if !inQuote && depth == 0 {
-				appendColType(inner[start:i])
+				parts = append(parts, s[start:i])
 				start = i + 1
 			}
 		}
 	}
-	appendColType(inner[start:])
-	return types
+	return append(parts, s[start:])
 }
 
 // extractBaseTypeName extracts the base type name from a type expression,

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -321,7 +321,8 @@ type ddlDiff struct {
 	// phase (before the view's DROP) would re-pin the old view and block its RESTRICT
 	// drop. They are created in the modify phase, AFTER generateModifyViewsSQL
 	// recreates the view (issue #480).
-	functionsAwaitingRecreatedViews []*ir.Function
+	functionsAwaitingRecreatedViews  []*ir.Function
+	aggregatesAwaitingRecreatedViews []*ir.Aggregate
 	// Foreign keys that depend on a unique/PK constraint being dropped or
 	// recreated by this migration: existing ones are dropped before the table
 	// modifications (fkPreDrops) and desired-state ones are (re)created
@@ -2056,6 +2057,9 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 	// state, or return type, or through a support function that does, are held
 	// back until the view and the view-dependent functions exist (#580).
 	aggregatesToCreateNow, aggregatesWithViewDeps := splitAggregatesByViewDeps(d.addedAggregates, newViewLookup, buildFunctionLookup(functionsWithViewDeps))
+	// Aggregates typed on a view being recreated, or built on a function that is,
+	// wait for the recreation in the modify phase, like those functions (issue #480).
+	aggregatesToCreateNow, d.aggregatesAwaitingRecreatedViews = splitAggregatesByViewDeps(aggregatesToCreateNow, recreatedViewLookup, buildFunctionLookup(d.functionsAwaitingRecreatedViews))
 	generateCreateAggregatesSQL(aggregatesToCreateNow, targetSchema, collector)
 
 	// Merge deferred policies from all batches
@@ -2107,38 +2111,18 @@ func (d *ddlDiff) generateCreateSQL(targetSchema string, collector *diffCollecto
 			}
 		}
 	}
-	// A view that calls a view-dependent function or aggregate must wait for that
-	// routine, which itself waits for the views it depends on. Hold such views,
-	// and any view built on them, until after the late routines exist (#580).
-	viewsToCreateNow, viewsAfterLateRoutines := splitViewsReferencingRoutines(viewsToCreateNow, buildRoutineLookup(functionsWithViewDeps, aggregatesWithViewDeps))
-	generateCreateViewsSQL(viewsToCreateNow, targetSchema, collector)
-
-	// If any views were deferred, also defer functions whose view dependency is
-	// on those deferred views, and aggregates built on such functions — they
-	// must be created after the views exist.
+	// If any views were deferred to the modify phase, also defer functions whose
+	// view dependency is on those deferred views, and aggregates built on such
+	// functions — they must be created after the views exist.
 	if len(d.deferredAddedViews) > 0 {
 		deferredViewLookup := buildViewLookup(d.deferredAddedViews)
 		functionsWithViewDeps, d.functionsAwaitingDeferredViews = splitFunctionsByViewDeps(functionsWithViewDeps, deferredViewLookup)
 		aggregatesWithViewDeps, d.aggregatesAwaitingDeferredViews = splitAggregatesByViewDeps(aggregatesWithViewDeps, deferredViewLookup, buildFunctionLookup(d.functionsAwaitingDeferredViews))
 	}
 
-	// Create functions WITH view dependencies (now that views exist)
-	// These functions reference views in their return type or parameter types (issue #300)
-	// Functions that depend on a held-back view, and aggregates built on them,
-	// are emitted after that view further below.
-	lateViewLookup := buildViewLookup(viewsAfterLateRoutines)
-	functionsWithViewDeps, functionsAfterLateViews := splitFunctionsByViewDeps(functionsWithViewDeps, lateViewLookup)
-	aggregatesWithViewDeps, aggregatesAfterLateViews := splitAggregatesByViewDeps(aggregatesWithViewDeps, lateViewLookup, buildFunctionLookup(functionsAfterLateViews))
-	generateCreateFunctionsSQL(functionsWithViewDeps, targetSchema, collector)
-
-	// Create aggregates that depend on a new view, after the view and after any
-	// support function that depends on it as well (#580).
-	generateCreateAggregatesSQL(aggregatesWithViewDeps, targetSchema, collector)
-
-	// Views that call the routines above, then the routines that depend on those views.
-	generateCreateViewsSQL(viewsAfterLateRoutines, targetSchema, collector)
-	generateCreateFunctionsSQL(functionsAfterLateViews, targetSchema, collector)
-	generateCreateAggregatesSQL(aggregatesAfterLateViews, targetSchema, collector)
+	// Create views, then the functions and aggregates that reference views in
+	// their signature or SQL body (issue #300, #580).
+	generateViewsAndDependentRoutinesSQL(viewsToCreateNow, functionsWithViewDeps, aggregatesWithViewDeps, targetSchema, collector)
 
 	// Revoke default grants on new tables that the user explicitly didn't include
 	// This must happen AFTER tables are created but BEFORE explicit grants
@@ -2191,15 +2175,7 @@ func (d *ddlDiff) generateModifySQL(targetSchema string, collector *diffCollecto
 	// Create views deferred from generateCreateSQL — their bodies reference
 	// columns just added by ALTER TABLE above (issue #414). Likewise, emit
 	// any functions whose view dependency was on those deferred views.
-	if len(d.deferredAddedViews) > 0 {
-		generateCreateViewsSQL(d.deferredAddedViews, targetSchema, collector)
-	}
-	if len(d.functionsAwaitingDeferredViews) > 0 {
-		generateCreateFunctionsSQL(d.functionsAwaitingDeferredViews, targetSchema, collector)
-	}
-	if len(d.aggregatesAwaitingDeferredViews) > 0 {
-		generateCreateAggregatesSQL(d.aggregatesAwaitingDeferredViews, targetSchema, collector)
-	}
+	generateViewsAndDependentRoutinesSQL(d.deferredAddedViews, d.functionsAwaitingDeferredViews, d.aggregatesAwaitingDeferredViews, targetSchema, collector)
 
 	// Find views that depend on views being recreated (issue #268, #308)
 	// Handles both materialized views and regular views with RequiresRecreate
@@ -2221,9 +2197,9 @@ func (d *ddlDiff) generateModifySQL(targetSchema string, collector *diffCollecto
 	// type references a view just recreated above. Emitting them now (rather than in
 	// the create phase) keeps the recreated view free of dependents during its
 	// RESTRICT drop (issue #480).
-	if len(d.functionsAwaitingRecreatedViews) > 0 {
-		generateCreateFunctionsSQL(d.functionsAwaitingRecreatedViews, targetSchema, collector)
-	}
+	// Aggregates built on those functions, or typed on the recreated view, follow.
+	generateCreateFunctionsSQL(d.functionsAwaitingRecreatedViews, targetSchema, collector)
+	generateCreateAggregatesSQL(d.aggregatesAwaitingRecreatedViews, targetSchema, collector)
 
 	// Modify functions
 	generateModifyFunctionsSQL(d.modifiedFunctions, targetSchema, collector)
@@ -2709,7 +2685,7 @@ func bodyReferencesRelation(body string, relations map[string]struct{}) bool {
 		if len(match) < 2 {
 			continue
 		}
-		if _, ok := relations[strings.ToLower(match[1])]; ok {
+		if _, ok := relations[normalizeRelationReference(match[1])]; ok {
 			return true
 		}
 	}
@@ -2794,6 +2770,24 @@ func splitAggregatesByViewDeps(aggregates []*ir.Aggregate, views, functions map[
 		}
 	}
 	return now, later
+}
+
+// generateViewsAndDependentRoutinesSQL creates views together with the functions
+// and aggregates that depend on them. A view that calls one of those routines is
+// created after it, and a routine that depends on such a view follows that view
+// in turn (#580). Every argument may be empty.
+func generateViewsAndDependentRoutinesSQL(views []*ir.View, functions []*ir.Function, aggregates []*ir.Aggregate, targetSchema string, collector *diffCollector) {
+	viewsNow, viewsLater := splitViewsReferencingRoutines(views, buildRoutineLookup(functions, aggregates))
+	lateViewLookup := buildViewLookup(viewsLater)
+	functionsNow, functionsLater := splitFunctionsByViewDeps(functions, lateViewLookup)
+	aggregatesNow, aggregatesLater := splitAggregatesByViewDeps(aggregates, lateViewLookup, buildFunctionLookup(functionsLater))
+
+	generateCreateViewsSQL(viewsNow, targetSchema, collector)
+	generateCreateFunctionsSQL(functionsNow, targetSchema, collector)
+	generateCreateAggregatesSQL(aggregatesNow, targetSchema, collector)
+	generateCreateViewsSQL(viewsLater, targetSchema, collector)
+	generateCreateFunctionsSQL(functionsLater, targetSchema, collector)
+	generateCreateAggregatesSQL(aggregatesLater, targetSchema, collector)
 }
 
 // splitViewsReferencingRoutines partitions views into those that can be created
@@ -3227,8 +3221,18 @@ func referencesNewFunction(expr, defaultSchema string, newFunctions map[string]s
 // Captures the table name (possibly schema-qualified) in group 1.
 var tableRefPattern = regexp.MustCompile(
 	`(?i)(?:FROM|JOIN|INTO|UPDATE(?:\s+ONLY)?|DELETE\s+FROM|TABLE)\s+` +
-		`([a-z_][a-z0-9_$]*(?:\.[a-z_][a-z0-9_$]*)*)`,
+		`((?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*")(?:\.(?:[a-z_][a-z0-9_$]*|"(?:[^"]|"")*"))*)`,
 )
+
+// normalizeRelationReference converts a relation reference captured by
+// tableRefPattern, possibly quoted and possibly schema-qualified, into the
+// lowercase "name" or "schema.name" key format of buildSchemaNameLookup.
+func normalizeRelationReference(raw string) string {
+	if idx := findLastUnquotedDot(raw); idx != -1 {
+		return strings.ToLower(unquoteIdent(raw[:idx]) + "." + unquoteIdent(raw[idx+1:]))
+	}
+	return strings.ToLower(unquoteIdent(raw))
+}
 
 // functionReferencesNewTable determines if a function references any newly
 // added table that will be created after the first function batch (tablesWithDeps).

--- a/internal/diff/relation_refs_test.go
+++ b/internal/diff/relation_refs_test.go
@@ -27,6 +27,10 @@ func TestRelationReferences(t *testing.T) {
 		{"DELETE FROM t WHERE id = 1", []string{"t"}},
 		{"SELECT * FROM v ORDER BY x, y", []string{"v"}},
 		{"SELECT * FROM v GROUP BY a, b", []string{"v"}},
+		{"DELETE FROM t USING v WHERE t.id = v.id", []string{"t", "v"}},
+		{"MERGE INTO t USING v ON t.id = v.id WHEN MATCHED THEN DELETE", []string{"t", "v"}},
+		{"SELECT * FROM t JOIN v USING (id)", []string{"t", "v"}},
+		{"SELECT * FROM unnest(xs) WITH ORDINALITY AS u(x, n), v", []string{"v"}},
 	}
 	for _, c := range cases {
 		if got := relationReferences(c.body); !reflect.DeepEqual(got, c.want) {

--- a/internal/diff/relation_refs_test.go
+++ b/internal/diff/relation_refs_test.go
@@ -1,0 +1,50 @@
+package diff
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRelationReferences(t *testing.T) {
+	cases := []struct {
+		body string
+		want []string
+	}{
+		{"SELECT count(*) FROM v", []string{"v"}},
+		{"SELECT * FROM t, v WHERE t.id = v.id", []string{"t", "v"}},
+		{"SELECT * FROM t AS a, v b, w", []string{"t", "v", "w"}},
+		{"SELECT * FROM unnest(xs) AS u(x), v", []string{"v"}},
+		{"SELECT * FROM (SELECT 1) AS s, v", []string{"v"}},
+		{"SELECT * FROM ONLY v", []string{"v"}},
+		{"SELECT * FROM ONLY (v)", []string{"v"}},
+		{"SELECT * FROM public . v", []string{"public . v"}},
+		{`SELECT * FROM "My View"`, []string{`"My View"`}},
+		{"SELECT * FROM t JOIN v ON t.id = v.id", []string{"t", "v"}},
+		{"SELECT * FROM v WHERE x IN (SELECT y FROM w)", []string{"v", "w"}},
+		{"INSERT INTO t(a, b) VALUES (1, 2)", []string{"t"}},
+		{"INSERT INTO t (a, b) SELECT a, b FROM v", []string{"t", "v"}},
+		{"UPDATE t SET a = 1", []string{"t"}},
+		{"DELETE FROM t WHERE id = 1", []string{"t"}},
+		{"SELECT * FROM v ORDER BY x, y", []string{"v"}},
+		{"SELECT * FROM v GROUP BY a, b", []string{"v"}},
+	}
+	for _, c := range cases {
+		if got := relationReferences(c.body); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("relationReferences(%q) = %v, want %v", c.body, got, c.want)
+		}
+	}
+}
+
+func TestStripLeadingIdentifier(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"r v", "v"},
+		{`"my col" numeric(10,2)`, "numeric(10,2)"},
+		{`"r""x" v`, "v"},
+		{"v", ""},
+	}
+	for _, c := range cases {
+		if got := stripLeadingIdentifier(c.in); got != c.want {
+			t.Errorf("stripLeadingIdentifier(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1308,18 +1308,13 @@ func (i *Inspector) stripSameSchemaPrefix(typeName, routineSchema string) string
 }
 
 // stripSameSchemaPrefixFromList is stripSameSchemaPrefix for a comma-separated
-// argument list such as pg_get_function_identity_arguments output. Both the raw
-// and the quote_ident form of the schema name are handled, so a schema that
-// needs quoting (e.g. "My Schema".v) normalizes the same way as public.v.
+// argument list such as pg_get_function_identity_arguments output. It strips a
+// schema qualifier only where an identifier token equal to the schema (bare or
+// quote_ident form) directly precedes a dot, so a schema that needs quoting
+// ("MySchema".v) normalizes like public.v while quoted names that merely
+// contain the schema text ("public.foo") are left intact.
 func (i *Inspector) stripSameSchemaPrefixFromList(list, schema string) string {
-	if list == "" || schema == "" {
-		return list
-	}
-	list = StripSchemaPrefixFromBody(list, schema)
-	if quoted := QuoteIdentifier(schema); quoted != schema {
-		list = StripSchemaPrefixFromBody(list, quoted)
-	}
-	return list
+	return StripSchemaQualifiers(list, schema)
 }
 
 // oidToTypeName maps PostgreSQL type OIDs to standard SQL type names.

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1409,10 +1409,13 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 
 		dbSchema := schema.getOrCreateSchema(schemaName)
 
-		// Argument, state, and return types may come back schema-qualified when the
-		// type is a relation's row type outside the search_path (e.g. "public.v").
-		// Strip the aggregate's own schema so both sides of a plan compare equal,
-		// mirroring what function parameters do via stripSameSchemaPrefix.
+		// Identity args, signature, and return type come from pg_get_function_*
+		// and format_type, which qualify a type only when it is outside the
+		// search_path, so the same aggregate can inspect as sum_v(v) on one side
+		// of a plan and sum_v(public.v) on the other. Strip the aggregate's own
+		// schema from those, mirroring function parameters. The state types are
+		// qualified explicitly by the query and stripped (or kept for
+		// --qualify-schema) by the diff layer, so they are left as is.
 		aggregate := &Aggregate{
 			Schema:     schemaName,
 			Name:       aggregateName,
@@ -1423,7 +1426,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 			Parallel:   i.safeInterfaceToString(agg.Parallel),
 
 			TransitionFunction: i.safeInterfaceToString(agg.TransitionFunction),
-			StateType:          i.stripSameSchemaPrefix(i.safeInterfaceToString(agg.StateType), schemaName),
+			StateType:          i.safeInterfaceToString(agg.StateType),
 			StateSpace:         int(agg.StateSpace),
 			InitialCondition:   initialCondition,
 
@@ -1437,7 +1440,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 
 			MTransitionFunction:    i.safeInterfaceToString(agg.MtransitionFunction),
 			MInvTransitionFunction: i.safeInterfaceToString(agg.MinvTransitionFunction),
-			MStateType:             i.stripSameSchemaPrefix(i.safeInterfaceToString(agg.MstateType), schemaName),
+			MStateType:             i.safeInterfaceToString(agg.MstateType),
 			MStateSpace:            int(agg.MstateSpace),
 			MFinalFunction:         i.safeInterfaceToString(agg.MfinalFunction),
 			MFinalFuncExtra:        agg.MfinalFuncExtra,

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1307,6 +1307,21 @@ func (i *Inspector) stripSameSchemaPrefix(typeName, routineSchema string) string
 	return typeName
 }
 
+// stripSameSchemaPrefixFromList is stripSameSchemaPrefix for a comma-separated
+// argument list such as pg_get_function_identity_arguments output. Both the raw
+// and the quote_ident form of the schema name are handled, so a schema that
+// needs quoting (e.g. "My Schema".v) normalizes the same way as public.v.
+func (i *Inspector) stripSameSchemaPrefixFromList(list, schema string) string {
+	if list == "" || schema == "" {
+		return list
+	}
+	list = StripSchemaPrefixFromBody(list, schema)
+	if quoted := QuoteIdentifier(schema); quoted != schema {
+		list = StripSchemaPrefixFromBody(list, quoted)
+	}
+	return list
+}
+
 // oidToTypeName maps PostgreSQL type OIDs to standard SQL type names.
 // Reference: https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat
 var oidToTypeName = map[int64]string{
@@ -1392,7 +1407,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 
 		// Identity args (types only) drive the DROP/COMMENT signature and the overload key.
 		// Strip the aggregate's own schema prefix here so the key and Arguments agree.
-		identityArgs := StripSchemaPrefixFromBody(i.safeInterfaceToString(agg.AggregateIdentityArgs), schemaName)
+		identityArgs := i.stripSameSchemaPrefixFromList(i.safeInterfaceToString(agg.AggregateIdentityArgs), schemaName)
 
 		// agginitval/aggminitval are nullable: preserve NULL (nil) vs explicit '' so an
 		// INITCOND/MINITCOND of empty string is not silently dropped.
@@ -1420,7 +1435,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 			Schema:     schemaName,
 			Name:       aggregateName,
 			Arguments:  identityArgs,
-			Signature:  StripSchemaPrefixFromBody(i.safeInterfaceToString(agg.AggregateSignature), schemaName),
+			Signature:  i.stripSameSchemaPrefixFromList(i.safeInterfaceToString(agg.AggregateSignature), schemaName),
 			Kind:       i.safeInterfaceToString(agg.AggregateKind),
 			ReturnType: i.stripSameSchemaPrefix(i.safeInterfaceToString(agg.AggregateReturnType), schemaName),
 			Parallel:   i.safeInterfaceToString(agg.Parallel),

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1408,17 +1408,21 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 
 		dbSchema := schema.getOrCreateSchema(schemaName)
 
+		// Argument, state, and return types may come back schema-qualified when the
+		// type is a relation's row type outside the search_path (e.g. "public.v").
+		// Strip the aggregate's own schema so both sides of a plan compare equal,
+		// mirroring what function parameters do via stripSameSchemaPrefix.
 		aggregate := &Aggregate{
 			Schema:     schemaName,
 			Name:       aggregateName,
-			Arguments:  identityArgs,
-			Signature:  i.safeInterfaceToString(agg.AggregateSignature),
+			Arguments:  StripSchemaPrefixFromBody(identityArgs, schemaName),
+			Signature:  StripSchemaPrefixFromBody(i.safeInterfaceToString(agg.AggregateSignature), schemaName),
 			Kind:       i.safeInterfaceToString(agg.AggregateKind),
-			ReturnType: i.safeInterfaceToString(agg.AggregateReturnType),
+			ReturnType: i.stripSameSchemaPrefix(i.safeInterfaceToString(agg.AggregateReturnType), schemaName),
 			Parallel:   i.safeInterfaceToString(agg.Parallel),
 
 			TransitionFunction: i.safeInterfaceToString(agg.TransitionFunction),
-			StateType:          i.safeInterfaceToString(agg.StateType),
+			StateType:          i.stripSameSchemaPrefix(i.safeInterfaceToString(agg.StateType), schemaName),
 			StateSpace:         int(agg.StateSpace),
 			InitialCondition:   initialCondition,
 
@@ -1432,7 +1436,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 
 			MTransitionFunction:    i.safeInterfaceToString(agg.MtransitionFunction),
 			MInvTransitionFunction: i.safeInterfaceToString(agg.MinvTransitionFunction),
-			MStateType:             i.safeInterfaceToString(agg.MstateType),
+			MStateType:             i.stripSameSchemaPrefix(i.safeInterfaceToString(agg.MstateType), schemaName),
 			MStateSpace:            int(agg.MstateSpace),
 			MFinalFunction:         i.safeInterfaceToString(agg.MfinalFunction),
 			MFinalFuncExtra:        agg.MfinalFuncExtra,

--- a/ir/inspector.go
+++ b/ir/inspector.go
@@ -1391,7 +1391,8 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 		aggregateName := agg.AggregateName
 
 		// Identity args (types only) drive the DROP/COMMENT signature and the overload key.
-		identityArgs := i.safeInterfaceToString(agg.AggregateIdentityArgs)
+		// Strip the aggregate's own schema prefix here so the key and Arguments agree.
+		identityArgs := StripSchemaPrefixFromBody(i.safeInterfaceToString(agg.AggregateIdentityArgs), schemaName)
 
 		// agginitval/aggminitval are nullable: preserve NULL (nil) vs explicit '' so an
 		// INITCOND/MINITCOND of empty string is not silently dropped.
@@ -1415,7 +1416,7 @@ func (i *Inspector) buildAggregates(ctx context.Context, schema *IR, targetSchem
 		aggregate := &Aggregate{
 			Schema:     schemaName,
 			Name:       aggregateName,
-			Arguments:  StripSchemaPrefixFromBody(identityArgs, schemaName),
+			Arguments:  identityArgs,
 			Signature:  StripSchemaPrefixFromBody(i.safeInterfaceToString(agg.AggregateSignature), schemaName),
 			Kind:       i.safeInterfaceToString(agg.AggregateKind),
 			ReturnType: i.stripSameSchemaPrefix(i.safeInterfaceToString(agg.AggregateReturnType), schemaName),

--- a/ir/normalize.go
+++ b/ir/normalize.go
@@ -503,6 +503,61 @@ func StripSchemaPrefixFromBody(body, schema string) string {
 	return result.String()
 }
 
+// StripSchemaQualifiers removes "schema." qualifiers from a string containing
+// SQL identifiers, such as a type or argument list, where the token directly
+// before an unquoted dot is the schema name in bare or quote_ident form.
+// Quoted identifiers are never modified, so a name like "public.foo" survives.
+func StripSchemaQualifiers(s, schema string) string {
+	if s == "" || schema == "" {
+		return s
+	}
+	var out strings.Builder
+	out.Grow(len(s))
+	for i := 0; i < len(s); {
+		start := i
+		switch {
+		case s[i] == '"':
+			// Quoted identifier: find the closing quote, honoring "" escapes.
+			i++
+			for i < len(s) {
+				if s[i] == '"' {
+					if i+1 < len(s) && s[i+1] == '"' {
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+		case isIdentChar(s[i]):
+			for i < len(s) && isIdentChar(s[i]) {
+				i++
+			}
+		default:
+			out.WriteByte(s[i])
+			i++
+			continue
+		}
+		token := s[start:i]
+		if i < len(s) && s[i] == '.' && unquoteIdentifier(token) == schema {
+			i++ // drop the schema token and its dot
+			continue
+		}
+		out.WriteString(token)
+	}
+	return out.String()
+}
+
+// unquoteIdentifier strips quote_ident double-quoting from a single identifier;
+// bare identifiers are returned unchanged.
+func unquoteIdentifier(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return strings.ReplaceAll(s[1:len(s)-1], `""`, `"`)
+	}
+	return s
+}
+
 // isIdentChar returns true if the byte is a valid SQL identifier character.
 func isIdentChar(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_' || b == '$'

--- a/ir/strip_schema_qualifiers_test.go
+++ b/ir/strip_schema_qualifiers_test.go
@@ -1,0 +1,23 @@
+package ir
+
+import "testing"
+
+func TestStripSchemaQualifiers(t *testing.T) {
+	cases := []struct{ in, schema, want string }{
+		{"r public.v", "public", "r v"},
+		{"public.v", "public", "v"},
+		{"ORDER BY public.v", "public", "ORDER BY v"},
+		{`x integer, "MySchema".v`, "MySchema", "x integer, v"},
+		{`"public.foo"`, "public", `"public.foo"`},
+		{`public."public.foo"`, "public", `"public.foo"`},
+		{"other.v", "public", "other.v"},
+		{"not_public.v", "public", "not_public.v"},
+		{"numeric(10,2), public.v[]", "public", "numeric(10,2), v[]"},
+		{"", "public", ""},
+	}
+	for _, c := range cases {
+		if got := StripSchemaQualifiers(c.in, c.schema); got != c.want {
+			t.Errorf("StripSchemaQualifiers(%q, %q) = %q, want %q", c.in, c.schema, got, c.want)
+		}
+	}
+}

--- a/testdata/diff/create_aggregate/add_aggregate/diff.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/diff.sql
@@ -23,3 +23,12 @@ CREATE AGGREGATE my_agg(numeric) (
     FINALFUNC = numeric_first,
     INITCOND = '{}'
 );
+
+CREATE OR REPLACE FUNCTION first_of(
+    vals numeric[]
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)
+$$;

--- a/testdata/diff/create_aggregate/add_aggregate/diff.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/diff.sql
@@ -24,6 +24,16 @@ CREATE AGGREGATE my_agg(numeric) (
     INITCOND = '{}'
 );
 
+CREATE OR REPLACE FUNCTION b_sfunc(
+    state numeric,
+    x numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + my_agg(v) FROM unnest(ARRAY[x]) AS u(v)
+$$;
+
 CREATE OR REPLACE FUNCTION first_of(
     vals numeric[]
 )
@@ -32,3 +42,9 @@ LANGUAGE sql
 IMMUTABLE
 AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)
 $$;
+
+CREATE AGGREGATE b_agg(numeric) (
+    SFUNC = b_sfunc,
+    STYPE = numeric,
+    INITCOND = '0'
+);

--- a/testdata/diff/create_aggregate/add_aggregate/new.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/new.sql
@@ -18,3 +18,15 @@ CREATE AGGREGATE my_agg(numeric) (
 CREATE FUNCTION first_of(vals numeric[]) RETURNS numeric
     LANGUAGE sql IMMUTABLE
     AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x) $$;
+
+-- Aggregate whose SQL transition function calls the first aggregate: the
+-- required order is my_agg -> b_sfunc -> b_agg.
+CREATE FUNCTION b_sfunc(state numeric, x numeric) RETURNS numeric
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT state + my_agg(v) FROM unnest(ARRAY[x]) AS u(v) $$;
+
+CREATE AGGREGATE b_agg(numeric) (
+    SFUNC = b_sfunc,
+    STYPE = numeric,
+    INITCOND = '0'
+);

--- a/testdata/diff/create_aggregate/add_aggregate/new.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/new.sql
@@ -12,3 +12,9 @@ CREATE AGGREGATE my_agg(numeric) (
     FINALFUNC = numeric_first,
     INITCOND = '{}'
 );
+
+-- SQL-language function calling the new aggregate. PostgreSQL resolves the
+-- call at creation, so the function must be created after the aggregate.
+CREATE FUNCTION first_of(vals numeric[]) RETURNS numeric
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x) $$;

--- a/testdata/diff/create_aggregate/add_aggregate/plan.json
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.json
@@ -25,6 +25,12 @@
           "type": "aggregate",
           "operation": "create",
           "path": "public.my_agg"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION first_of(\n    vals numeric[]\n)\nRETURNS numeric\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.first_of"
         }
       ]
     }

--- a/testdata/diff/create_aggregate/add_aggregate/plan.json
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.json
@@ -27,10 +27,22 @@
           "path": "public.my_agg"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION b_sfunc(\n    state numeric,\n    x numeric\n)\nRETURNS numeric\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + my_agg(v) FROM unnest(ARRAY[x]) AS u(v)\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.b_sfunc"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION first_of(\n    vals numeric[]\n)\nRETURNS numeric\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)\n$$;",
           "type": "function",
           "operation": "create",
           "path": "public.first_of"
+        },
+        {
+          "sql": "CREATE AGGREGATE b_agg(numeric) (\n    SFUNC = b_sfunc,\n    STYPE = numeric,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.b_agg"
         }
       ]
     }

--- a/testdata/diff/create_aggregate/add_aggregate/plan.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.sql
@@ -23,3 +23,12 @@ CREATE AGGREGATE my_agg(numeric) (
     FINALFUNC = numeric_first,
     INITCOND = '{}'
 );
+
+CREATE OR REPLACE FUNCTION first_of(
+    vals numeric[]
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)
+$$;

--- a/testdata/diff/create_aggregate/add_aggregate/plan.sql
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.sql
@@ -24,6 +24,16 @@ CREATE AGGREGATE my_agg(numeric) (
     INITCOND = '{}'
 );
 
+CREATE OR REPLACE FUNCTION b_sfunc(
+    state numeric,
+    x numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + my_agg(v) FROM unnest(ARRAY[x]) AS u(v)
+$$;
+
 CREATE OR REPLACE FUNCTION first_of(
     vals numeric[]
 )
@@ -32,3 +42,9 @@ LANGUAGE sql
 IMMUTABLE
 AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)
 $$;
+
+CREATE AGGREGATE b_agg(numeric) (
+    SFUNC = b_sfunc,
+    STYPE = numeric,
+    INITCOND = '0'
+);

--- a/testdata/diff/create_aggregate/add_aggregate/plan.txt
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.txt
@@ -1,15 +1,17 @@
-Plan: 4 to add.
+Plan: 6 to add.
 
 Summary by type:
-  functions: 3 to add
-  aggregates: 1 to add
+  functions: 4 to add
+  aggregates: 2 to add
 
 Functions:
+  + b_sfunc
   + first_of
   + numeric_accum
   + numeric_first
 
 Aggregates:
+  + b_agg
   + my_agg
 
 DDL to be executed:
@@ -41,6 +43,16 @@ CREATE AGGREGATE my_agg(numeric) (
     INITCOND = '{}'
 );
 
+CREATE OR REPLACE FUNCTION b_sfunc(
+    state numeric,
+    x numeric
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + my_agg(v) FROM unnest(ARRAY[x]) AS u(v)
+$$;
+
 CREATE OR REPLACE FUNCTION first_of(
     vals numeric[]
 )
@@ -49,3 +61,9 @@ LANGUAGE sql
 IMMUTABLE
 AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)
 $$;
+
+CREATE AGGREGATE b_agg(numeric) (
+    SFUNC = b_sfunc,
+    STYPE = numeric,
+    INITCOND = '0'
+);

--- a/testdata/diff/create_aggregate/add_aggregate/plan.txt
+++ b/testdata/diff/create_aggregate/add_aggregate/plan.txt
@@ -1,10 +1,11 @@
-Plan: 3 to add.
+Plan: 4 to add.
 
 Summary by type:
-  functions: 2 to add
+  functions: 3 to add
   aggregates: 1 to add
 
 Functions:
+  + first_of
   + numeric_accum
   + numeric_first
 
@@ -39,3 +40,12 @@ CREATE AGGREGATE my_agg(numeric) (
     FINALFUNC = numeric_first,
     INITCOND = '{}'
 );
+
+CREATE OR REPLACE FUNCTION first_of(
+    vals numeric[]
+)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT my_agg(x) FROM unnest(vals) AS u(x)
+$$;

--- a/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/diff.sql
+++ b/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/diff.sql
@@ -10,9 +10,29 @@ CREATE OR REPLACE VIEW foo_summary AS
  SELECT id
    FROM foo_base;
 
+CREATE OR REPLACE FUNCTION foo_summary_step(
+    state bigint,
+    r foo_summary
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
+$$;
+
 CREATE OR REPLACE FUNCTION get_foo_summary()
 RETURNS SETOF foo_summary
 LANGUAGE sql
 STABLE
 AS $$ SELECT * FROM foo_summary
 $$;
+
+CREATE AGGREGATE sum_foo_summary(foo_summary) (
+    SFUNC = foo_summary_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+CREATE OR REPLACE VIEW foo_total AS
+ SELECT sum_foo_summary(foo_summary.*) AS total
+   FROM foo_summary;

--- a/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/new.sql
+++ b/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/new.sql
@@ -13,3 +13,19 @@ CREATE OR REPLACE FUNCTION get_foo_summary()
     RETURNS SETOF foo_summary
     LANGUAGE sql STABLE
     AS $$ SELECT * FROM foo_summary $$;
+
+-- Aggregate over the deferred view's row type, and a view that calls it. The
+-- view must follow the aggregate, which follows its transition function (#580).
+CREATE OR REPLACE FUNCTION foo_summary_step(state bigint, r foo_summary)
+    RETURNS bigint
+    LANGUAGE sql IMMUTABLE
+    AS $$ SELECT state + r.id $$;
+
+CREATE AGGREGATE sum_foo_summary(foo_summary) (
+    SFUNC = foo_summary_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+CREATE OR REPLACE VIEW foo_total AS
+SELECT sum_foo_summary(foo_summary.*) AS total FROM foo_summary;

--- a/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/plan.json
+++ b/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/plan.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "pgschema_version": "1.9.0",
+  "pgschema_version": "1.12.5",
   "created_at": "1970-01-01T00:00:00Z",
   "source_fingerprint": {
     "hash": "e1fb0e7b8fda0362df6ecdbc88f6910f1faaa4d896de95796aa412b913e18858"
@@ -27,10 +27,28 @@
           "path": "public.foo_summary"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION foo_summary_step(\n    state bigint,\n    r foo_summary\n)\nRETURNS bigint\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + r.id\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.foo_summary_step"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION get_foo_summary()\nRETURNS SETOF foo_summary\nLANGUAGE sql\nSTABLE\nAS $$ SELECT * FROM foo_summary\n$$;",
           "type": "function",
           "operation": "create",
           "path": "public.get_foo_summary"
+        },
+        {
+          "sql": "CREATE AGGREGATE sum_foo_summary(foo_summary) (\n    SFUNC = foo_summary_step,\n    STYPE = bigint,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.sum_foo_summary"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW foo_total AS\n SELECT sum_foo_summary(foo_summary.*) AS total\n   FROM foo_summary;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.foo_total"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/plan.sql
+++ b/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/plan.sql
@@ -10,9 +10,29 @@ CREATE OR REPLACE VIEW foo_summary AS
  SELECT id
    FROM foo_base;
 
+CREATE OR REPLACE FUNCTION foo_summary_step(
+    state bigint,
+    r foo_summary
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
+$$;
+
 CREATE OR REPLACE FUNCTION get_foo_summary()
 RETURNS SETOF foo_summary
 LANGUAGE sql
 STABLE
 AS $$ SELECT * FROM foo_summary
 $$;
+
+CREATE AGGREGATE sum_foo_summary(foo_summary) (
+    SFUNC = foo_summary_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+CREATE OR REPLACE VIEW foo_total AS
+ SELECT sum_foo_summary(foo_summary.*) AS total
+   FROM foo_summary;

--- a/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/plan.txt
+++ b/testdata/diff/dependency/issue_414_function_returns_deferred_view_chain/plan.txt
@@ -1,12 +1,17 @@
-Plan: 3 to add, 1 to modify.
+Plan: 6 to add, 1 to modify.
 
 Summary by type:
-  functions: 1 to add
+  functions: 2 to add
+  aggregates: 1 to add
   tables: 1 to modify
-  views: 2 to add
+  views: 3 to add
 
 Functions:
+  + foo_summary_step
   + get_foo_summary
+
+Aggregates:
+  + sum_foo_summary
 
 Tables:
   ~ foo
@@ -15,6 +20,7 @@ Tables:
 Views:
   + foo_base
   + foo_summary
+  + foo_total
 
 DDL to be executed:
 --------------------------------------------------
@@ -31,9 +37,29 @@ CREATE OR REPLACE VIEW foo_summary AS
  SELECT id
    FROM foo_base;
 
+CREATE OR REPLACE FUNCTION foo_summary_step(
+    state bigint,
+    r foo_summary
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
+$$;
+
 CREATE OR REPLACE FUNCTION get_foo_summary()
 RETURNS SETOF foo_summary
 LANGUAGE sql
 STABLE
 AS $$ SELECT * FROM foo_summary
 $$;
+
+CREATE AGGREGATE sum_foo_summary(foo_summary) (
+    SFUNC = foo_summary_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+CREATE OR REPLACE VIEW foo_total AS
+ SELECT sum_foo_summary(foo_summary.*) AS total
+   FROM foo_summary;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
@@ -30,3 +30,19 @@ BEGIN
     RETURN v_result;
 END;
 $$;
+
+CREATE OR REPLACE FUNCTION fn_users_step(
+    state bigint,
+    u vw_users
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + 1
+$$;
+
+CREATE AGGREGATE agg_users_count(vw_users) (
+    SFUNC = fn_users_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
@@ -1,5 +1,10 @@
 DROP FUNCTION IF EXISTS fn_create_user(text);
 
+CREATE OR REPLACE VIEW vw_active AS
+ SELECT id
+   FROM tb_users
+  WHERE is_deleted = false;
+
 ALTER TABLE tb_users ADD COLUMN role text DEFAULT 'member' NOT NULL;
 
 DROP VIEW IF EXISTS vw_users RESTRICT;
@@ -31,6 +36,17 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION fn_pair_step(
+    state bigint,
+    u vw_users,
+    a vw_active
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + 1
+$$;
+
 CREATE OR REPLACE FUNCTION fn_users_step(
     state bigint,
     u vw_users
@@ -41,8 +57,18 @@ IMMUTABLE
 AS $$ SELECT state + 1
 $$;
 
+CREATE AGGREGATE agg_pair(vw_users, vw_active) (
+    SFUNC = fn_pair_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
 CREATE AGGREGATE agg_users_count(vw_users) (
     SFUNC = fn_users_step,
     STYPE = bigint,
     INITCOND = '0'
 );
+
+CREATE OR REPLACE VIEW vw_users_count AS
+ SELECT agg_users_count(vw_users.*) AS n
+   FROM vw_users;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
@@ -69,22 +69,6 @@ CREATE AGGREGATE agg_users_count(vw_users) (
     INITCOND = '0'
 );
 
-CREATE OR REPLACE FUNCTION active_marker(
-    a vw_active
-)
-RETURNS bigint
-LANGUAGE sql
-VOLATILE
-AS $$ SELECT agg_users_count(NULL::vw_users)
-$$;
-
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;
-
-CREATE OR REPLACE VIEW vw_role_counts AS
- SELECT u.role,
-    agg_users_count(vw_users.*) AS n
-   FROM tb_users u
-     JOIN vw_users ON vw_users.id = u.id
-  GROUP BY u.role;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
@@ -72,3 +72,10 @@ CREATE AGGREGATE agg_users_count(vw_users) (
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;
+
+CREATE OR REPLACE VIEW vw_role_counts AS
+ SELECT u.role,
+    agg_users_count(vw_users.*) AS n
+   FROM tb_users u
+     JOIN vw_users ON vw_users.id = u.id
+  GROUP BY u.role;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/diff.sql
@@ -69,6 +69,15 @@ CREATE AGGREGATE agg_users_count(vw_users) (
     INITCOND = '0'
 );
 
+CREATE OR REPLACE FUNCTION active_marker(
+    a vw_active
+)
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT agg_users_count(NULL::vw_users)
+$$;
+
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
@@ -23,3 +23,14 @@ BEGIN
     RETURN v_result;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Aggregate whose transition function is typed on the recreated view. Both
+-- must be created after the view is recreated in the modify phase (#580).
+CREATE FUNCTION fn_users_step(state bigint, u vw_users)
+RETURNS bigint LANGUAGE sql IMMUTABLE AS $$ SELECT state + 1 $$;
+
+CREATE AGGREGATE agg_users_count(vw_users) (
+    SFUNC = fn_users_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
@@ -52,3 +52,10 @@ CREATE AGGREGATE agg_pair(vw_users, vw_active) (
 -- New view calling an aggregate held for the recreation: created after it.
 CREATE VIEW vw_users_count AS
 SELECT agg_users_count(vw_users.*) AS n FROM vw_users;
+
+-- View deferred for the added column (issue #414 path) that also calls an
+-- aggregate held for the recreation: it joins the recreated-view batch.
+CREATE VIEW vw_role_counts AS
+SELECT u.role, agg_users_count(vw_users.*) AS n
+FROM tb_users u JOIN vw_users ON vw_users.id = u.id
+GROUP BY u.role;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
@@ -59,3 +59,9 @@ CREATE VIEW vw_role_counts AS
 SELECT u.role, agg_users_count(vw_users.*) AS n
 FROM tb_users u JOIN vw_users ON vw_users.id = u.id
 GROUP BY u.role;
+
+-- View-dependent function (typed on the new view) whose SQL body calls an
+-- aggregate held for the recreation, without naming the recreated view: it
+-- must join the recreated-view batch.
+CREATE FUNCTION active_marker(a vw_active) RETURNS bigint
+LANGUAGE sql AS $$ SELECT agg_users_count(NULL::vw_users) $$;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
@@ -52,16 +52,3 @@ CREATE AGGREGATE agg_pair(vw_users, vw_active) (
 -- New view calling an aggregate held for the recreation: created after it.
 CREATE VIEW vw_users_count AS
 SELECT agg_users_count(vw_users.*) AS n FROM vw_users;
-
--- View deferred for the added column (issue #414 path) that also calls an
--- aggregate held for the recreation: it joins the recreated-view batch.
-CREATE VIEW vw_role_counts AS
-SELECT u.role, agg_users_count(vw_users.*) AS n
-FROM tb_users u JOIN vw_users ON vw_users.id = u.id
-GROUP BY u.role;
-
--- View-dependent function (typed on the new view) whose SQL body calls an
--- aggregate held for the recreation, without naming the recreated view: it
--- must join the recreated-view batch.
-CREATE FUNCTION active_marker(a vw_active) RETURNS bigint
-LANGUAGE sql AS $$ SELECT agg_users_count(NULL::vw_users) $$;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/new.sql
@@ -34,3 +34,21 @@ CREATE AGGREGATE agg_users_count(vw_users) (
     STYPE = bigint,
     INITCOND = '0'
 );
+
+-- Aggregate that depends on a new view AND (through its transition function)
+-- on the recreated view: it must still wait for the recreation.
+CREATE VIEW vw_active AS
+SELECT id FROM tb_users WHERE is_deleted = FALSE;
+
+CREATE FUNCTION fn_pair_step(state bigint, u vw_users, a vw_active)
+RETURNS bigint LANGUAGE sql IMMUTABLE AS $$ SELECT state + 1 $$;
+
+CREATE AGGREGATE agg_pair(vw_users, vw_active) (
+    SFUNC = fn_pair_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+-- New view calling an aggregate held for the recreation: created after it.
+CREATE VIEW vw_users_count AS
+SELECT agg_users_count(vw_users.*) AS n FROM vw_users;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
@@ -69,22 +69,10 @@
           "path": "public.agg_users_count"
         },
         {
-          "sql": "CREATE OR REPLACE FUNCTION active_marker(\n    a vw_active\n)\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT agg_users_count(NULL::vw_users)\n$$;",
-          "type": "function",
-          "operation": "create",
-          "path": "public.active_marker"
-        },
-        {
           "sql": "CREATE OR REPLACE VIEW vw_users_count AS\n SELECT agg_users_count(vw_users.*) AS n\n   FROM vw_users;",
           "type": "view",
           "operation": "create",
           "path": "public.vw_users_count"
-        },
-        {
-          "sql": "CREATE OR REPLACE VIEW vw_role_counts AS\n SELECT u.role,\n    agg_users_count(vw_users.*) AS n\n   FROM tb_users u\n     JOIN vw_users ON vw_users.id = u.id\n  GROUP BY u.role;",
-          "type": "view",
-          "operation": "create",
-          "path": "public.vw_role_counts"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
@@ -73,6 +73,12 @@
           "type": "view",
           "operation": "create",
           "path": "public.vw_users_count"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW vw_role_counts AS\n SELECT u.role,\n    agg_users_count(vw_users.*) AS n\n   FROM tb_users u\n     JOIN vw_users ON vw_users.id = u.id\n  GROUP BY u.role;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.vw_role_counts"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
@@ -15,6 +15,12 @@
           "path": "public.fn_create_user"
         },
         {
+          "sql": "CREATE OR REPLACE VIEW vw_active AS\n SELECT id\n   FROM tb_users\n  WHERE is_deleted = false;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.vw_active"
+        },
+        {
           "sql": "ALTER TABLE tb_users ADD COLUMN role text DEFAULT 'member' NOT NULL;",
           "type": "table.column",
           "operation": "create",
@@ -39,16 +45,34 @@
           "path": "public.fn_create_user"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION fn_pair_step(\n    state bigint,\n    u vw_users,\n    a vw_active\n)\nRETURNS bigint\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + 1\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.fn_pair_step"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION fn_users_step(\n    state bigint,\n    u vw_users\n)\nRETURNS bigint\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + 1\n$$;",
           "type": "function",
           "operation": "create",
           "path": "public.fn_users_step"
         },
         {
+          "sql": "CREATE AGGREGATE agg_pair(vw_users, vw_active) (\n    SFUNC = fn_pair_step,\n    STYPE = bigint,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.agg_pair"
+        },
+        {
           "sql": "CREATE AGGREGATE agg_users_count(vw_users) (\n    SFUNC = fn_users_step,\n    STYPE = bigint,\n    INITCOND = '0'\n);",
           "type": "aggregate",
           "operation": "create",
           "path": "public.agg_users_count"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW vw_users_count AS\n SELECT agg_users_count(vw_users.*) AS n\n   FROM vw_users;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.vw_users_count"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
@@ -37,6 +37,18 @@
           "type": "function",
           "operation": "create",
           "path": "public.fn_create_user"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION fn_users_step(\n    state bigint,\n    u vw_users\n)\nRETURNS bigint\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + 1\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.fn_users_step"
+        },
+        {
+          "sql": "CREATE AGGREGATE agg_users_count(vw_users) (\n    SFUNC = fn_users_step,\n    STYPE = bigint,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.agg_users_count"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.json
@@ -69,6 +69,12 @@
           "path": "public.agg_users_count"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION active_marker(\n    a vw_active\n)\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT agg_users_count(NULL::vw_users)\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.active_marker"
+        },
+        {
           "sql": "CREATE OR REPLACE VIEW vw_users_count AS\n SELECT agg_users_count(vw_users.*) AS n\n   FROM vw_users;",
           "type": "view",
           "operation": "create",

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
@@ -30,3 +30,19 @@ BEGIN
     RETURN v_result;
 END;
 $$;
+
+CREATE OR REPLACE FUNCTION fn_users_step(
+    state bigint,
+    u vw_users
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + 1
+$$;
+
+CREATE AGGREGATE agg_users_count(vw_users) (
+    SFUNC = fn_users_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
@@ -1,5 +1,10 @@
 DROP FUNCTION IF EXISTS fn_create_user(text);
 
+CREATE OR REPLACE VIEW vw_active AS
+ SELECT id
+   FROM tb_users
+  WHERE is_deleted = false;
+
 ALTER TABLE tb_users ADD COLUMN role text DEFAULT 'member' NOT NULL;
 
 DROP VIEW IF EXISTS vw_users RESTRICT;
@@ -31,6 +36,17 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION fn_pair_step(
+    state bigint,
+    u vw_users,
+    a vw_active
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + 1
+$$;
+
 CREATE OR REPLACE FUNCTION fn_users_step(
     state bigint,
     u vw_users
@@ -41,8 +57,18 @@ IMMUTABLE
 AS $$ SELECT state + 1
 $$;
 
+CREATE AGGREGATE agg_pair(vw_users, vw_active) (
+    SFUNC = fn_pair_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
 CREATE AGGREGATE agg_users_count(vw_users) (
     SFUNC = fn_users_step,
     STYPE = bigint,
     INITCOND = '0'
 );
+
+CREATE OR REPLACE VIEW vw_users_count AS
+ SELECT agg_users_count(vw_users.*) AS n
+   FROM vw_users;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
@@ -69,22 +69,6 @@ CREATE AGGREGATE agg_users_count(vw_users) (
     INITCOND = '0'
 );
 
-CREATE OR REPLACE FUNCTION active_marker(
-    a vw_active
-)
-RETURNS bigint
-LANGUAGE sql
-VOLATILE
-AS $$ SELECT agg_users_count(NULL::vw_users)
-$$;
-
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;
-
-CREATE OR REPLACE VIEW vw_role_counts AS
- SELECT u.role,
-    agg_users_count(vw_users.*) AS n
-   FROM tb_users u
-     JOIN vw_users ON vw_users.id = u.id
-  GROUP BY u.role;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
@@ -72,3 +72,10 @@ CREATE AGGREGATE agg_users_count(vw_users) (
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;
+
+CREATE OR REPLACE VIEW vw_role_counts AS
+ SELECT u.role,
+    agg_users_count(vw_users.*) AS n
+   FROM tb_users u
+     JOIN vw_users ON vw_users.id = u.id
+  GROUP BY u.role;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.sql
@@ -69,6 +69,15 @@ CREATE AGGREGATE agg_users_count(vw_users) (
     INITCOND = '0'
 );
 
+CREATE OR REPLACE FUNCTION active_marker(
+    a vw_active
+)
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT agg_users_count(NULL::vw_users)
+$$;
+
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
@@ -1,12 +1,13 @@
-Plan: 8 to add, 2 to modify, 1 to drop.
+Plan: 9 to add, 2 to modify, 1 to drop.
 
 Summary by type:
-  functions: 3 to add, 1 to drop
+  functions: 4 to add, 1 to drop
   aggregates: 2 to add
   tables: 1 to modify
   views: 3 to add, 1 to modify
 
 Functions:
+  + active_marker
   - fn_create_user
   + fn_create_user
   + fn_pair_step
@@ -99,6 +100,15 @@ CREATE AGGREGATE agg_users_count(vw_users) (
     STYPE = bigint,
     INITCOND = '0'
 );
+
+CREATE OR REPLACE FUNCTION active_marker(
+    a vw_active
+)
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT agg_users_count(NULL::vw_users)
+$$;
 
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
@@ -1,13 +1,18 @@
-Plan: 1 to add, 2 to modify, 1 to drop.
+Plan: 3 to add, 2 to modify, 1 to drop.
 
 Summary by type:
-  functions: 1 to add, 1 to drop
+  functions: 2 to add, 1 to drop
+  aggregates: 1 to add
   tables: 1 to modify
   views: 1 to modify
 
 Functions:
   - fn_create_user
   + fn_create_user
+  + fn_users_step
+
+Aggregates:
+  + agg_users_count
 
 Tables:
   ~ tb_users
@@ -51,3 +56,19 @@ BEGIN
     RETURN v_result;
 END;
 $$;
+
+CREATE OR REPLACE FUNCTION fn_users_step(
+    state bigint,
+    u vw_users
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + 1
+$$;
+
+CREATE AGGREGATE agg_users_count(vw_users) (
+    SFUNC = fn_users_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
@@ -1,17 +1,19 @@
-Plan: 3 to add, 2 to modify, 1 to drop.
+Plan: 7 to add, 2 to modify, 1 to drop.
 
 Summary by type:
-  functions: 2 to add, 1 to drop
-  aggregates: 1 to add
+  functions: 3 to add, 1 to drop
+  aggregates: 2 to add
   tables: 1 to modify
-  views: 1 to modify
+  views: 2 to add, 1 to modify
 
 Functions:
   - fn_create_user
   + fn_create_user
+  + fn_pair_step
   + fn_users_step
 
 Aggregates:
+  + agg_pair
   + agg_users_count
 
 Tables:
@@ -19,12 +21,19 @@ Tables:
     + role (column)
 
 Views:
+  + vw_active
   ~ vw_users
+  + vw_users_count
 
 DDL to be executed:
 --------------------------------------------------
 
 DROP FUNCTION IF EXISTS fn_create_user(text);
+
+CREATE OR REPLACE VIEW vw_active AS
+ SELECT id
+   FROM tb_users
+  WHERE is_deleted = false;
 
 ALTER TABLE tb_users ADD COLUMN role text DEFAULT 'member' NOT NULL;
 
@@ -57,6 +66,17 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION fn_pair_step(
+    state bigint,
+    u vw_users,
+    a vw_active
+)
+RETURNS bigint
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + 1
+$$;
+
 CREATE OR REPLACE FUNCTION fn_users_step(
     state bigint,
     u vw_users
@@ -67,8 +87,18 @@ IMMUTABLE
 AS $$ SELECT state + 1
 $$;
 
+CREATE AGGREGATE agg_pair(vw_users, vw_active) (
+    SFUNC = fn_pair_step,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
 CREATE AGGREGATE agg_users_count(vw_users) (
     SFUNC = fn_users_step,
     STYPE = bigint,
     INITCOND = '0'
 );
+
+CREATE OR REPLACE VIEW vw_users_count AS
+ SELECT agg_users_count(vw_users.*) AS n
+   FROM vw_users;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
@@ -1,10 +1,10 @@
-Plan: 7 to add, 2 to modify, 1 to drop.
+Plan: 8 to add, 2 to modify, 1 to drop.
 
 Summary by type:
   functions: 3 to add, 1 to drop
   aggregates: 2 to add
   tables: 1 to modify
-  views: 2 to add, 1 to modify
+  views: 3 to add, 1 to modify
 
 Functions:
   - fn_create_user
@@ -22,6 +22,7 @@ Tables:
 
 Views:
   + vw_active
+  + vw_role_counts
   ~ vw_users
   + vw_users_count
 
@@ -102,3 +103,10 @@ CREATE AGGREGATE agg_users_count(vw_users) (
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;
+
+CREATE OR REPLACE VIEW vw_role_counts AS
+ SELECT u.role,
+    agg_users_count(vw_users.*) AS n
+   FROM tb_users u
+     JOIN vw_users ON vw_users.id = u.id
+  GROUP BY u.role;

--- a/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
+++ b/testdata/diff/dependency/issue_480_view_function_recreate/plan.txt
@@ -1,13 +1,12 @@
-Plan: 9 to add, 2 to modify, 1 to drop.
+Plan: 7 to add, 2 to modify, 1 to drop.
 
 Summary by type:
-  functions: 4 to add, 1 to drop
+  functions: 3 to add, 1 to drop
   aggregates: 2 to add
   tables: 1 to modify
-  views: 3 to add, 1 to modify
+  views: 2 to add, 1 to modify
 
 Functions:
-  + active_marker
   - fn_create_user
   + fn_create_user
   + fn_pair_step
@@ -23,7 +22,6 @@ Tables:
 
 Views:
   + vw_active
-  + vw_role_counts
   ~ vw_users
   + vw_users_count
 
@@ -101,22 +99,6 @@ CREATE AGGREGATE agg_users_count(vw_users) (
     INITCOND = '0'
 );
 
-CREATE OR REPLACE FUNCTION active_marker(
-    a vw_active
-)
-RETURNS bigint
-LANGUAGE sql
-VOLATILE
-AS $$ SELECT agg_users_count(NULL::vw_users)
-$$;
-
 CREATE OR REPLACE VIEW vw_users_count AS
  SELECT agg_users_count(vw_users.*) AS n
    FROM vw_users;
-
-CREATE OR REPLACE VIEW vw_role_counts AS
- SELECT u.role,
-    agg_users_count(vw_users.*) AS n
-   FROM tb_users u
-     JOIN vw_users ON vw_users.id = u.id
-  GROUP BY u.role;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -20,6 +20,10 @@ CREATE OR REPLACE VIEW "My View" AS
  SELECT id
    FROM t;
 
+CREATE OR REPLACE VIEW "Order By V" AS
+ SELECT id
+   FROM t;
+
 CREATE OR REPLACE VIEW v AS
  SELECT id,
     name
@@ -49,11 +53,28 @@ VOLATILE
 AS $$ SELECT count(*) FROM ONLY v
 $$;
 
+CREATE OR REPLACE FUNCTION count_spaced_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM public . v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT count(*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION ob_sfunc(
+    state integer,
+    r "Order By V"
+)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
 $$;
 
 CREATE OR REPLACE FUNCTION v_sfunc(
@@ -72,6 +93,12 @@ CREATE AGGREGATE count_ordered_v(ORDER BY v) (
     FINALFUNC_MODIFY = READ_WRITE,
     INITCOND = '0',
     MFINALFUNC_MODIFY = READ_WRITE
+);
+
+CREATE AGGREGATE sum_ob("Order By V") (
+    SFUNC = ob_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
 );
 
 CREATE AGGREGATE sum_v(v) (
@@ -97,6 +124,13 @@ RETURNS integer
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_v(v.*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION total_with_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT sum_with_v(id) FROM t
 $$;
 
 CREATE OR REPLACE VIEW v_total AS

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -74,6 +74,20 @@ VOLATILE
 AS $$ SELECT count(*) FROM public . v
 $$;
 
+CREATE OR REPLACE FUNCTION count_sub_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM (SELECT 1) AS s, v
+$$;
+
+CREATE OR REPLACE FUNCTION count_unnest_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM unnest(ARRAY[1]) AS u(x), v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -133,6 +147,16 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
+CREATE OR REPLACE FUNCTION chain_sfunc(
+    state integer,
+    x integer
+)
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)
+$$;
+
 CREATE OR REPLACE FUNCTION total_v()
 RETURNS integer
 LANGUAGE sql
@@ -146,6 +170,12 @@ LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_with_v(id) FROM t
 $$;
+
+CREATE AGGREGATE chain_agg(integer) (
+    SFUNC = chain_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
 
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -92,6 +92,13 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
+CREATE OR REPLACE FUNCTION total_v()
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT sum_v(v.*) FROM v
+$$;
+
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total
    FROM v;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS t (
+    id integer,
+    name text,
+    CONSTRAINT t_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION touch_t()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$ BEGIN PERFORM 1 FROM v; RETURN NEW; END
+$$;
+
+CREATE OR REPLACE TRIGGER touch_trg
+    BEFORE INSERT ON t
+    FOR EACH ROW
+    EXECUTE FUNCTION touch_t();
+
+CREATE OR REPLACE VIEW v AS
+ SELECT id,
+    name
+   FROM t;
+
+CREATE OR REPLACE FUNCTION count_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION v_sfunc(
+    state integer,
+    r v
+)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
+$$;
+
+CREATE AGGREGATE sum_v(v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -21,6 +21,16 @@ CREATE OR REPLACE VIEW v AS
     name
    FROM t;
 
+CREATE OR REPLACE FUNCTION acc_with_v(
+    state bigint,
+    x integer
+)
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT state + x + (SELECT count(*) FROM v)
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -43,3 +53,20 @@ CREATE AGGREGATE sum_v(v) (
     STYPE = integer,
     INITCOND = '0'
 );
+
+CREATE AGGREGATE sum_with_v(integer) (
+    SFUNC = acc_with_v,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+CREATE OR REPLACE VIEW v_total AS
+ SELECT sum_v(v.*) AS total
+   FROM v;
+
+CREATE OR REPLACE FUNCTION get_total()
+RETURNS SETOF v_total
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT * FROM v_total
+$$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -16,6 +16,10 @@ CREATE OR REPLACE TRIGGER touch_trg
     FOR EACH ROW
     EXECUTE FUNCTION touch_t();
 
+CREATE OR REPLACE VIEW "My View" AS
+ SELECT id
+   FROM t;
+
 CREATE OR REPLACE VIEW v AS
  SELECT id,
     name
@@ -29,6 +33,13 @@ RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT state + x + (SELECT count(*) FROM v)
+$$;
+
+CREATE OR REPLACE FUNCTION count_my_view()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM "My View"
 $$;
 
 CREATE OR REPLACE FUNCTION count_v()

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -42,6 +42,13 @@ VOLATILE
 AS $$ SELECT count(*) FROM "My View"
 $$;
 
+CREATE OR REPLACE FUNCTION count_only_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM ONLY v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -59,7 +66,21 @@ IMMUTABLE
 AS $$ SELECT state + r.id
 $$;
 
+CREATE AGGREGATE count_ordered_v(ORDER BY v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    FINALFUNC_MODIFY = READ_WRITE,
+    INITCOND = '0',
+    MFINALFUNC_MODIFY = READ_WRITE
+);
+
 CREATE AGGREGATE sum_v(v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+
+CREATE AGGREGATE sum_v_named(r v) (
     SFUNC = v_sfunc,
     STYPE = integer,
     INITCOND = '0'

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -147,16 +147,6 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
-CREATE OR REPLACE FUNCTION chain_sfunc(
-    state integer,
-    x integer
-)
-RETURNS integer
-LANGUAGE sql
-VOLATILE
-AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)
-$$;
-
 CREATE OR REPLACE FUNCTION total_v()
 RETURNS integer
 LANGUAGE sql
@@ -170,12 +160,6 @@ LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_with_v(id) FROM t
 $$;
-
-CREATE AGGREGATE chain_agg(integer) (
-    SFUNC = chain_sfunc,
-    STYPE = integer,
-    INITCOND = '0'
-);
 
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/diff.sql
@@ -39,6 +39,13 @@ VOLATILE
 AS $$ SELECT state + x + (SELECT count(*) FROM v)
 $$;
 
+CREATE OR REPLACE FUNCTION count_list_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM t, v
+$$;
+
 CREATE OR REPLACE FUNCTION count_my_view()
 RETURNS bigint
 LANGUAGE sql
@@ -51,6 +58,13 @@ RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT count(*) FROM ONLY v
+$$;
+
+CREATE OR REPLACE FUNCTION count_paren_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM ONLY (v)
 $$;
 
 CREATE OR REPLACE FUNCTION count_spaced_v()

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -73,3 +73,23 @@ CREATE FUNCTION count_my_view()
 RETURNS bigint
 LANGUAGE sql
 AS $$ SELECT count(*) FROM "My View" $$;
+
+-- Named argument and ordered-set forms of a view row-type argument. Identity
+-- args read "r v" and "ORDER BY v", and both must still count as view deps.
+CREATE AGGREGATE sum_v_named(r v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+
+CREATE AGGREGATE count_ordered_v(ORDER BY v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+
+-- FROM ONLY is valid syntax and must still be detected as a view reference.
+CREATE FUNCTION count_only_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM ONLY v $$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -41,3 +41,26 @@ CREATE AGGREGATE sum_v(v) (
     STYPE = integer,
     INITCOND = '0'
 );
+
+-- Aggregate with ordinary types whose transition function queries the view.
+-- The function is view-dependent, so the aggregate must follow it.
+CREATE FUNCTION acc_with_v(state bigint, x integer)
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT state + x + (SELECT count(*) FROM v) $$;
+
+CREATE AGGREGATE sum_with_v(integer) (
+    SFUNC = acc_with_v,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+-- View that calls the aggregate over v's row type, and a function returning
+-- that view's row type. Both must follow the aggregate.
+CREATE VIEW v_total AS
+SELECT sum_v(v.*) AS total FROM v;
+
+CREATE FUNCTION get_total()
+RETURNS SETOF v_total
+LANGUAGE sql
+AS $$ SELECT * FROM v_total $$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -153,16 +153,3 @@ CREATE FUNCTION count_sub_v()
 RETURNS bigint
 LANGUAGE sql
 AS $$ SELECT count(*) FROM (SELECT 1) AS s, v $$;
-
--- Aggregate with ordinary types whose SQL transition function calls the
--- view-dependent aggregate: chain sum_v -> chain_sfunc -> chain_agg.
-CREATE FUNCTION chain_sfunc(state integer, x integer)
-RETURNS integer
-LANGUAGE sql
-AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0) $$;
-
-CREATE AGGREGATE chain_agg(integer) (
-    SFUNC = chain_sfunc,
-    STYPE = integer,
-    INITCOND = '0'
-);

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -93,3 +93,10 @@ CREATE FUNCTION count_only_v()
 RETURNS bigint
 LANGUAGE sql
 AS $$ SELECT count(*) FROM ONLY v $$;
+
+-- SQL-language function calling the view-dependent aggregate: it must follow
+-- the aggregate even though both are in the view-dependent batch.
+CREATE FUNCTION total_v()
+RETURNS integer
+LANGUAGE sql
+AS $$ SELECT sum_v(v.*) FROM v $$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -142,3 +142,27 @@ CREATE FUNCTION count_paren_v()
 RETURNS bigint
 LANGUAGE sql
 AS $$ SELECT count(*) FROM ONLY (v) $$;
+
+-- Function-call and subquery items ahead of v in a FROM list must not hide it.
+CREATE FUNCTION count_unnest_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM unnest(ARRAY[1]) AS u(x), v $$;
+
+CREATE FUNCTION count_sub_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM (SELECT 1) AS s, v $$;
+
+-- Aggregate with ordinary types whose SQL transition function calls the
+-- view-dependent aggregate: chain sum_v -> chain_sfunc -> chain_agg.
+CREATE FUNCTION chain_sfunc(state integer, x integer)
+RETURNS integer
+LANGUAGE sql
+AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0) $$;
+
+CREATE AGGREGATE chain_agg(integer) (
+    SFUNC = chain_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -100,3 +100,33 @@ CREATE FUNCTION total_v()
 RETURNS integer
 LANGUAGE sql
 AS $$ SELECT sum_v(v.*) FROM v $$;
+
+-- SQL-language function calling an aggregate that is held for the view batch
+-- (sum_with_v's transition function queries v) without mentioning the view
+-- itself: it must still follow that aggregate.
+CREATE FUNCTION total_with_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT sum_with_v(id) FROM t $$;
+
+-- Whitespace around the qualification dot is valid and must still match.
+CREATE FUNCTION count_spaced_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM public . v $$;
+
+-- A quoted view name containing the ordered-set separator must not be split.
+CREATE VIEW "Order By V" AS
+SELECT id FROM t;
+
+CREATE FUNCTION ob_sfunc(state integer, r "Order By V")
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id $$;
+
+CREATE AGGREGATE sum_ob("Order By V") (
+    SFUNC = ob_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -130,3 +130,15 @@ CREATE AGGREGATE sum_ob("Order By V") (
     STYPE = integer,
     INITCOND = '0'
 );
+
+-- Comma-separated FROM list and the parenthesized ONLY form must both be
+-- recognized as references to v.
+CREATE FUNCTION count_list_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM t, v $$;
+
+CREATE FUNCTION count_paren_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM ONLY (v) $$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -64,3 +64,12 @@ CREATE FUNCTION get_total()
 RETURNS SETOF v_total
 LANGUAGE sql
 AS $$ SELECT * FROM v_total $$;
+
+-- A quoted view name in a SQL-language body must still count as a dependency.
+CREATE VIEW "My View" AS
+SELECT id FROM t;
+
+CREATE FUNCTION count_my_view()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM "My View" $$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/new.sql
@@ -1,0 +1,43 @@
+-- Issue #580: objects that depend on a view existing at creation time.
+
+CREATE TABLE t (
+    id integer PRIMARY KEY,
+    name text
+);
+
+CREATE VIEW v AS
+SELECT id, name FROM t;
+
+-- SQL-language function whose body queries the view. PostgreSQL validates a
+-- SQL body at creation, so this must be created after the view.
+CREATE FUNCTION count_v()
+RETURNS bigint
+LANGUAGE sql
+AS $$ SELECT count(*) FROM v $$;
+
+-- plpgsql trigger function whose body mentions the view. The body is not
+-- validated against relations at creation, so it must NOT be deferred past
+-- the trigger that references it (triggers are created before views).
+CREATE FUNCTION touch_t()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$ BEGIN PERFORM 1 FROM v; RETURN NEW; END $$;
+
+CREATE TRIGGER touch_trg
+BEFORE INSERT ON t
+FOR EACH ROW EXECUTE FUNCTION touch_t();
+
+-- Aggregate whose input type is the view's row type. Its transition function
+-- takes the row type too, so the aggregate must follow both the view and the
+-- view-dependent function.
+CREATE FUNCTION v_sfunc(state integer, r v)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id $$;
+
+CREATE AGGREGATE sum_v(v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -141,12 +141,6 @@
           "path": "public.sum_with_v"
         },
         {
-          "sql": "CREATE OR REPLACE FUNCTION chain_sfunc(\n    state integer,\n    x integer\n)\nRETURNS integer\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)\n$$;",
-          "type": "function",
-          "operation": "create",
-          "path": "public.chain_sfunc"
-        },
-        {
           "sql": "CREATE OR REPLACE FUNCTION total_v()\nRETURNS integer\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT sum_v(v.*) FROM v\n$$;",
           "type": "function",
           "operation": "create",
@@ -157,12 +151,6 @@
           "type": "function",
           "operation": "create",
           "path": "public.total_with_v"
-        },
-        {
-          "sql": "CREATE AGGREGATE chain_agg(integer) (\n    SFUNC = chain_sfunc,\n    STYPE = integer,\n    INITCOND = '0'\n);",
-          "type": "aggregate",
-          "operation": "create",
-          "path": "public.chain_agg"
         },
         {
           "sql": "CREATE OR REPLACE VIEW v_total AS\n SELECT sum_v(v.*) AS total\n   FROM v;",

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -81,6 +81,18 @@
           "path": "public.count_spaced_v"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION count_sub_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM (SELECT 1) AS s, v\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_sub_v"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION count_unnest_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM unnest(ARRAY[1]) AS u(x), v\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_unnest_v"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION count_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM v\n$$;",
           "type": "function",
           "operation": "create",
@@ -129,6 +141,12 @@
           "path": "public.sum_with_v"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION chain_sfunc(\n    state integer,\n    x integer\n)\nRETURNS integer\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.chain_sfunc"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION total_v()\nRETURNS integer\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT sum_v(v.*) FROM v\n$$;",
           "type": "function",
           "operation": "create",
@@ -139,6 +157,12 @@
           "type": "function",
           "operation": "create",
           "path": "public.total_with_v"
+        },
+        {
+          "sql": "CREATE AGGREGATE chain_agg(integer) (\n    SFUNC = chain_sfunc,\n    STYPE = integer,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.chain_agg"
         },
         {
           "sql": "CREATE OR REPLACE VIEW v_total AS\n SELECT sum_v(v.*) AS total\n   FROM v;",

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -93,6 +93,12 @@
           "path": "public.sum_with_v"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION total_v()\nRETURNS integer\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT sum_v(v.*) FROM v\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.total_v"
+        },
+        {
           "sql": "CREATE OR REPLACE VIEW v_total AS\n SELECT sum_v(v.*) AS total\n   FROM v;",
           "type": "view",
           "operation": "create",

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0.0",
+  "pgschema_version": "1.12.5",
+  "created_at": "1970-01-01T00:00:00Z",
+  "source_fingerprint": {
+    "hash": "965b1131737c955e24c7f827c55bd78e4cb49a75adfd04229e0ba297376f5085"
+  },
+  "groups": [
+    {
+      "steps": [
+        {
+          "sql": "CREATE TABLE IF NOT EXISTS t (\n    id integer,\n    name text,\n    CONSTRAINT t_pkey PRIMARY KEY (id)\n);",
+          "type": "table",
+          "operation": "create",
+          "path": "public.t"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION touch_t()\nRETURNS trigger\nLANGUAGE plpgsql\nVOLATILE\nAS $$ BEGIN PERFORM 1 FROM v; RETURN NEW; END\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.touch_t"
+        },
+        {
+          "sql": "CREATE OR REPLACE TRIGGER touch_trg\n    BEFORE INSERT ON t\n    FOR EACH ROW\n    EXECUTE FUNCTION touch_t();",
+          "type": "table.trigger",
+          "operation": "create",
+          "path": "public.t.touch_trg"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW v AS\n SELECT id,\n    name\n   FROM t;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.v"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION count_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM v\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_v"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION v_sfunc(\n    state integer,\n    r v\n)\nRETURNS integer\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + r.id\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.v_sfunc"
+        },
+        {
+          "sql": "CREATE AGGREGATE sum_v(v) (\n    SFUNC = v_sfunc,\n    STYPE = integer,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.sum_v"
+        }
+      ]
+    }
+  ]
+}

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -51,6 +51,12 @@
           "path": "public.count_my_view"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION count_only_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM ONLY v\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_only_v"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION count_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM v\n$$;",
           "type": "function",
           "operation": "create",
@@ -63,10 +69,22 @@
           "path": "public.v_sfunc"
         },
         {
+          "sql": "CREATE AGGREGATE count_ordered_v(ORDER BY v) (\n    SFUNC = v_sfunc,\n    STYPE = integer,\n    FINALFUNC_MODIFY = READ_WRITE,\n    INITCOND = '0',\n    MFINALFUNC_MODIFY = READ_WRITE\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.count_ordered_v"
+        },
+        {
           "sql": "CREATE AGGREGATE sum_v(v) (\n    SFUNC = v_sfunc,\n    STYPE = integer,\n    INITCOND = '0'\n);",
           "type": "aggregate",
           "operation": "create",
           "path": "public.sum_v"
+        },
+        {
+          "sql": "CREATE AGGREGATE sum_v_named(r v) (\n    SFUNC = v_sfunc,\n    STYPE = integer,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.sum_v_named"
         },
         {
           "sql": "CREATE AGGREGATE sum_with_v(integer) (\n    SFUNC = acc_with_v,\n    STYPE = bigint,\n    INITCOND = '0'\n);",

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -27,6 +27,12 @@
           "path": "public.t.touch_trg"
         },
         {
+          "sql": "CREATE OR REPLACE VIEW \"My View\" AS\n SELECT id\n   FROM t;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.My View"
+        },
+        {
           "sql": "CREATE OR REPLACE VIEW v AS\n SELECT id,\n    name\n   FROM t;",
           "type": "view",
           "operation": "create",
@@ -37,6 +43,12 @@
           "type": "function",
           "operation": "create",
           "path": "public.acc_with_v"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION count_my_view()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM \"My View\"\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_my_view"
         },
         {
           "sql": "CREATE OR REPLACE FUNCTION count_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM v\n$$;",

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -51,6 +51,12 @@
           "path": "public.acc_with_v"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION count_list_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM t, v\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_list_v"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION count_my_view()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM \"My View\"\n$$;",
           "type": "function",
           "operation": "create",
@@ -61,6 +67,12 @@
           "type": "function",
           "operation": "create",
           "path": "public.count_only_v"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION count_paren_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM ONLY (v)\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_paren_v"
         },
         {
           "sql": "CREATE OR REPLACE FUNCTION count_spaced_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM public . v\n$$;",

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -33,6 +33,12 @@
           "path": "public.My View"
         },
         {
+          "sql": "CREATE OR REPLACE VIEW \"Order By V\" AS\n SELECT id\n   FROM t;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.Order By V"
+        },
+        {
           "sql": "CREATE OR REPLACE VIEW v AS\n SELECT id,\n    name\n   FROM t;",
           "type": "view",
           "operation": "create",
@@ -57,10 +63,22 @@
           "path": "public.count_only_v"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION count_spaced_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM public . v\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.count_spaced_v"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION count_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM v\n$$;",
           "type": "function",
           "operation": "create",
           "path": "public.count_v"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION ob_sfunc(\n    state integer,\n    r \"Order By V\"\n)\nRETURNS integer\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + r.id\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.ob_sfunc"
         },
         {
           "sql": "CREATE OR REPLACE FUNCTION v_sfunc(\n    state integer,\n    r v\n)\nRETURNS integer\nLANGUAGE sql\nIMMUTABLE\nAS $$ SELECT state + r.id\n$$;",
@@ -73,6 +91,12 @@
           "type": "aggregate",
           "operation": "create",
           "path": "public.count_ordered_v"
+        },
+        {
+          "sql": "CREATE AGGREGATE sum_ob(\"Order By V\") (\n    SFUNC = ob_sfunc,\n    STYPE = integer,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.sum_ob"
         },
         {
           "sql": "CREATE AGGREGATE sum_v(v) (\n    SFUNC = v_sfunc,\n    STYPE = integer,\n    INITCOND = '0'\n);",
@@ -97,6 +121,12 @@
           "type": "function",
           "operation": "create",
           "path": "public.total_v"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION total_with_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT sum_with_v(id) FROM t\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.total_with_v"
         },
         {
           "sql": "CREATE OR REPLACE VIEW v_total AS\n SELECT sum_v(v.*) AS total\n   FROM v;",

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.json
@@ -33,6 +33,12 @@
           "path": "public.v"
         },
         {
+          "sql": "CREATE OR REPLACE FUNCTION acc_with_v(\n    state bigint,\n    x integer\n)\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT state + x + (SELECT count(*) FROM v)\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.acc_with_v"
+        },
+        {
           "sql": "CREATE OR REPLACE FUNCTION count_v()\nRETURNS bigint\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT count(*) FROM v\n$$;",
           "type": "function",
           "operation": "create",
@@ -49,6 +55,24 @@
           "type": "aggregate",
           "operation": "create",
           "path": "public.sum_v"
+        },
+        {
+          "sql": "CREATE AGGREGATE sum_with_v(integer) (\n    SFUNC = acc_with_v,\n    STYPE = bigint,\n    INITCOND = '0'\n);",
+          "type": "aggregate",
+          "operation": "create",
+          "path": "public.sum_with_v"
+        },
+        {
+          "sql": "CREATE OR REPLACE VIEW v_total AS\n SELECT sum_v(v.*) AS total\n   FROM v;",
+          "type": "view",
+          "operation": "create",
+          "path": "public.v_total"
+        },
+        {
+          "sql": "CREATE OR REPLACE FUNCTION get_total()\nRETURNS SETOF v_total\nLANGUAGE sql\nVOLATILE\nAS $$ SELECT * FROM v_total\n$$;",
+          "type": "function",
+          "operation": "create",
+          "path": "public.get_total"
         }
       ]
     }

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -20,6 +20,10 @@ CREATE OR REPLACE VIEW "My View" AS
  SELECT id
    FROM t;
 
+CREATE OR REPLACE VIEW "Order By V" AS
+ SELECT id
+   FROM t;
+
 CREATE OR REPLACE VIEW v AS
  SELECT id,
     name
@@ -49,11 +53,28 @@ VOLATILE
 AS $$ SELECT count(*) FROM ONLY v
 $$;
 
+CREATE OR REPLACE FUNCTION count_spaced_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM public . v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT count(*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION ob_sfunc(
+    state integer,
+    r "Order By V"
+)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
 $$;
 
 CREATE OR REPLACE FUNCTION v_sfunc(
@@ -72,6 +93,12 @@ CREATE AGGREGATE count_ordered_v(ORDER BY v) (
     FINALFUNC_MODIFY = READ_WRITE,
     INITCOND = '0',
     MFINALFUNC_MODIFY = READ_WRITE
+);
+
+CREATE AGGREGATE sum_ob("Order By V") (
+    SFUNC = ob_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
 );
 
 CREATE AGGREGATE sum_v(v) (
@@ -97,6 +124,13 @@ RETURNS integer
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_v(v.*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION total_with_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT sum_with_v(id) FROM t
 $$;
 
 CREATE OR REPLACE VIEW v_total AS

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -74,6 +74,20 @@ VOLATILE
 AS $$ SELECT count(*) FROM public . v
 $$;
 
+CREATE OR REPLACE FUNCTION count_sub_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM (SELECT 1) AS s, v
+$$;
+
+CREATE OR REPLACE FUNCTION count_unnest_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM unnest(ARRAY[1]) AS u(x), v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -133,6 +147,16 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
+CREATE OR REPLACE FUNCTION chain_sfunc(
+    state integer,
+    x integer
+)
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)
+$$;
+
 CREATE OR REPLACE FUNCTION total_v()
 RETURNS integer
 LANGUAGE sql
@@ -146,6 +170,12 @@ LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_with_v(id) FROM t
 $$;
+
+CREATE AGGREGATE chain_agg(integer) (
+    SFUNC = chain_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
 
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -92,6 +92,13 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
+CREATE OR REPLACE FUNCTION total_v()
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT sum_v(v.*) FROM v
+$$;
+
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total
    FROM v;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS t (
+    id integer,
+    name text,
+    CONSTRAINT t_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION touch_t()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$ BEGIN PERFORM 1 FROM v; RETURN NEW; END
+$$;
+
+CREATE OR REPLACE TRIGGER touch_trg
+    BEFORE INSERT ON t
+    FOR EACH ROW
+    EXECUTE FUNCTION touch_t();
+
+CREATE OR REPLACE VIEW v AS
+ SELECT id,
+    name
+   FROM t;
+
+CREATE OR REPLACE FUNCTION count_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION v_sfunc(
+    state integer,
+    r v
+)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
+$$;
+
+CREATE AGGREGATE sum_v(v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -21,6 +21,16 @@ CREATE OR REPLACE VIEW v AS
     name
    FROM t;
 
+CREATE OR REPLACE FUNCTION acc_with_v(
+    state bigint,
+    x integer
+)
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT state + x + (SELECT count(*) FROM v)
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -43,3 +53,20 @@ CREATE AGGREGATE sum_v(v) (
     STYPE = integer,
     INITCOND = '0'
 );
+
+CREATE AGGREGATE sum_with_v(integer) (
+    SFUNC = acc_with_v,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+CREATE OR REPLACE VIEW v_total AS
+ SELECT sum_v(v.*) AS total
+   FROM v;
+
+CREATE OR REPLACE FUNCTION get_total()
+RETURNS SETOF v_total
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT * FROM v_total
+$$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -16,6 +16,10 @@ CREATE OR REPLACE TRIGGER touch_trg
     FOR EACH ROW
     EXECUTE FUNCTION touch_t();
 
+CREATE OR REPLACE VIEW "My View" AS
+ SELECT id
+   FROM t;
+
 CREATE OR REPLACE VIEW v AS
  SELECT id,
     name
@@ -29,6 +33,13 @@ RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT state + x + (SELECT count(*) FROM v)
+$$;
+
+CREATE OR REPLACE FUNCTION count_my_view()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM "My View"
 $$;
 
 CREATE OR REPLACE FUNCTION count_v()

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -42,6 +42,13 @@ VOLATILE
 AS $$ SELECT count(*) FROM "My View"
 $$;
 
+CREATE OR REPLACE FUNCTION count_only_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM ONLY v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -59,7 +66,21 @@ IMMUTABLE
 AS $$ SELECT state + r.id
 $$;
 
+CREATE AGGREGATE count_ordered_v(ORDER BY v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    FINALFUNC_MODIFY = READ_WRITE,
+    INITCOND = '0',
+    MFINALFUNC_MODIFY = READ_WRITE
+);
+
 CREATE AGGREGATE sum_v(v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+
+CREATE AGGREGATE sum_v_named(r v) (
     SFUNC = v_sfunc,
     STYPE = integer,
     INITCOND = '0'

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -147,16 +147,6 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
-CREATE OR REPLACE FUNCTION chain_sfunc(
-    state integer,
-    x integer
-)
-RETURNS integer
-LANGUAGE sql
-VOLATILE
-AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)
-$$;
-
 CREATE OR REPLACE FUNCTION total_v()
 RETURNS integer
 LANGUAGE sql
@@ -170,12 +160,6 @@ LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_with_v(id) FROM t
 $$;
-
-CREATE AGGREGATE chain_agg(integer) (
-    SFUNC = chain_sfunc,
-    STYPE = integer,
-    INITCOND = '0'
-);
 
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.sql
@@ -39,6 +39,13 @@ VOLATILE
 AS $$ SELECT state + x + (SELECT count(*) FROM v)
 $$;
 
+CREATE OR REPLACE FUNCTION count_list_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM t, v
+$$;
+
 CREATE OR REPLACE FUNCTION count_my_view()
 RETURNS bigint
 LANGUAGE sql
@@ -51,6 +58,13 @@ RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT count(*) FROM ONLY v
+$$;
+
+CREATE OR REPLACE FUNCTION count_paren_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM ONLY (v)
 $$;
 
 CREATE OR REPLACE FUNCTION count_spaced_v()

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,18 +1,21 @@
-Plan: 23 to add.
+Plan: 27 to add.
 
 Summary by type:
-  functions: 13 to add
-  aggregates: 5 to add
+  functions: 16 to add
+  aggregates: 6 to add
   tables: 1 to add
   views: 4 to add
 
 Functions:
   + acc_with_v
+  + chain_sfunc
   + count_list_v
   + count_my_view
   + count_only_v
   + count_paren_v
   + count_spaced_v
+  + count_sub_v
+  + count_unnest_v
   + count_v
   + get_total
   + ob_sfunc
@@ -22,6 +25,7 @@ Functions:
   + v_sfunc
 
 Aggregates:
+  + chain_agg
   + count_ordered_v
   + sum_ob
   + sum_v
@@ -117,6 +121,20 @@ VOLATILE
 AS $$ SELECT count(*) FROM public . v
 $$;
 
+CREATE OR REPLACE FUNCTION count_sub_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM (SELECT 1) AS s, v
+$$;
+
+CREATE OR REPLACE FUNCTION count_unnest_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM unnest(ARRAY[1]) AS u(x), v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -176,6 +194,16 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
+CREATE OR REPLACE FUNCTION chain_sfunc(
+    state integer,
+    x integer
+)
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)
+$$;
+
 CREATE OR REPLACE FUNCTION total_v()
 RETURNS integer
 LANGUAGE sql
@@ -189,6 +217,12 @@ LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_with_v(id) FROM t
 $$;
+
+CREATE AGGREGATE chain_agg(integer) (
+    SFUNC = chain_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
 
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,0 +1,71 @@
+Plan: 6 to add.
+
+Summary by type:
+  functions: 3 to add
+  aggregates: 1 to add
+  tables: 1 to add
+  views: 1 to add
+
+Functions:
+  + count_v
+  + touch_t
+  + v_sfunc
+
+Aggregates:
+  + sum_v
+
+Tables:
+  + t
+    + touch_trg (trigger)
+
+Views:
+  + v
+
+DDL to be executed:
+--------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS t (
+    id integer,
+    name text,
+    CONSTRAINT t_pkey PRIMARY KEY (id)
+);
+
+CREATE OR REPLACE FUNCTION touch_t()
+RETURNS trigger
+LANGUAGE plpgsql
+VOLATILE
+AS $$ BEGIN PERFORM 1 FROM v; RETURN NEW; END
+$$;
+
+CREATE OR REPLACE TRIGGER touch_trg
+    BEFORE INSERT ON t
+    FOR EACH ROW
+    EXECUTE FUNCTION touch_t();
+
+CREATE OR REPLACE VIEW v AS
+ SELECT id,
+    name
+   FROM t;
+
+CREATE OR REPLACE FUNCTION count_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION v_sfunc(
+    state integer,
+    r v
+)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
+$$;
+
+CREATE AGGREGATE sum_v(v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,7 +1,7 @@
-Plan: 15 to add.
+Plan: 16 to add.
 
 Summary by type:
-  functions: 7 to add
+  functions: 8 to add
   aggregates: 4 to add
   tables: 1 to add
   views: 3 to add
@@ -12,6 +12,7 @@ Functions:
   + count_only_v
   + count_v
   + get_total
+  + total_v
   + touch_t
   + v_sfunc
 
@@ -126,6 +127,13 @@ CREATE AGGREGATE sum_with_v(integer) (
     STYPE = bigint,
     INITCOND = '0'
 );
+
+CREATE OR REPLACE FUNCTION total_v()
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT sum_v(v.*) FROM v
+$$;
 
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,23 +1,27 @@
-Plan: 16 to add.
+Plan: 21 to add.
 
 Summary by type:
-  functions: 8 to add
-  aggregates: 4 to add
+  functions: 11 to add
+  aggregates: 5 to add
   tables: 1 to add
-  views: 3 to add
+  views: 4 to add
 
 Functions:
   + acc_with_v
   + count_my_view
   + count_only_v
+  + count_spaced_v
   + count_v
   + get_total
+  + ob_sfunc
   + total_v
+  + total_with_v
   + touch_t
   + v_sfunc
 
 Aggregates:
   + count_ordered_v
+  + sum_ob
   + sum_v
   + sum_v_named
   + sum_with_v
@@ -28,6 +32,7 @@ Tables:
 
 Views:
   + My View
+  + Order By V
   + v
   + v_total
 
@@ -53,6 +58,10 @@ CREATE OR REPLACE TRIGGER touch_trg
     EXECUTE FUNCTION touch_t();
 
 CREATE OR REPLACE VIEW "My View" AS
+ SELECT id
+   FROM t;
+
+CREATE OR REPLACE VIEW "Order By V" AS
  SELECT id
    FROM t;
 
@@ -85,11 +94,28 @@ VOLATILE
 AS $$ SELECT count(*) FROM ONLY v
 $$;
 
+CREATE OR REPLACE FUNCTION count_spaced_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM public . v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT count(*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION ob_sfunc(
+    state integer,
+    r "Order By V"
+)
+RETURNS integer
+LANGUAGE sql
+IMMUTABLE
+AS $$ SELECT state + r.id
 $$;
 
 CREATE OR REPLACE FUNCTION v_sfunc(
@@ -108,6 +134,12 @@ CREATE AGGREGATE count_ordered_v(ORDER BY v) (
     FINALFUNC_MODIFY = READ_WRITE,
     INITCOND = '0',
     MFINALFUNC_MODIFY = READ_WRITE
+);
+
+CREATE AGGREGATE sum_ob("Order By V") (
+    SFUNC = ob_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
 );
 
 CREATE AGGREGATE sum_v(v) (
@@ -133,6 +165,13 @@ RETURNS integer
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_v(v.*) FROM v
+$$;
+
+CREATE OR REPLACE FUNCTION total_with_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT sum_with_v(id) FROM t
 $$;
 
 CREATE OR REPLACE VIEW v_total AS

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,13 +1,14 @@
-Plan: 10 to add.
+Plan: 12 to add.
 
 Summary by type:
-  functions: 5 to add
+  functions: 6 to add
   aggregates: 2 to add
   tables: 1 to add
-  views: 2 to add
+  views: 3 to add
 
 Functions:
   + acc_with_v
+  + count_my_view
   + count_v
   + get_total
   + touch_t
@@ -22,6 +23,7 @@ Tables:
     + touch_trg (trigger)
 
 Views:
+  + My View
   + v
   + v_total
 
@@ -46,6 +48,10 @@ CREATE OR REPLACE TRIGGER touch_trg
     FOR EACH ROW
     EXECUTE FUNCTION touch_t();
 
+CREATE OR REPLACE VIEW "My View" AS
+ SELECT id
+   FROM t;
+
 CREATE OR REPLACE VIEW v AS
  SELECT id,
     name
@@ -59,6 +65,13 @@ RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT state + x + (SELECT count(*) FROM v)
+$$;
+
+CREATE OR REPLACE FUNCTION count_my_view()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM "My View"
 $$;
 
 CREATE OR REPLACE FUNCTION count_v()

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,21 +1,24 @@
-Plan: 12 to add.
+Plan: 15 to add.
 
 Summary by type:
-  functions: 6 to add
-  aggregates: 2 to add
+  functions: 7 to add
+  aggregates: 4 to add
   tables: 1 to add
   views: 3 to add
 
 Functions:
   + acc_with_v
   + count_my_view
+  + count_only_v
   + count_v
   + get_total
   + touch_t
   + v_sfunc
 
 Aggregates:
+  + count_ordered_v
   + sum_v
+  + sum_v_named
   + sum_with_v
 
 Tables:
@@ -74,6 +77,13 @@ VOLATILE
 AS $$ SELECT count(*) FROM "My View"
 $$;
 
+CREATE OR REPLACE FUNCTION count_only_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM ONLY v
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -91,7 +101,21 @@ IMMUTABLE
 AS $$ SELECT state + r.id
 $$;
 
+CREATE AGGREGATE count_ordered_v(ORDER BY v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    FINALFUNC_MODIFY = READ_WRITE,
+    INITCOND = '0',
+    MFINALFUNC_MODIFY = READ_WRITE
+);
+
 CREATE AGGREGATE sum_v(v) (
+    SFUNC = v_sfunc,
+    STYPE = integer,
+    INITCOND = '0'
+);
+
+CREATE AGGREGATE sum_v_named(r v) (
     SFUNC = v_sfunc,
     STYPE = integer,
     INITCOND = '0'

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,14 +1,13 @@
-Plan: 27 to add.
+Plan: 25 to add.
 
 Summary by type:
-  functions: 16 to add
-  aggregates: 6 to add
+  functions: 15 to add
+  aggregates: 5 to add
   tables: 1 to add
   views: 4 to add
 
 Functions:
   + acc_with_v
-  + chain_sfunc
   + count_list_v
   + count_my_view
   + count_only_v
@@ -25,7 +24,6 @@ Functions:
   + v_sfunc
 
 Aggregates:
-  + chain_agg
   + count_ordered_v
   + sum_ob
   + sum_v
@@ -194,16 +192,6 @@ CREATE AGGREGATE sum_with_v(integer) (
     INITCOND = '0'
 );
 
-CREATE OR REPLACE FUNCTION chain_sfunc(
-    state integer,
-    x integer
-)
-RETURNS integer
-LANGUAGE sql
-VOLATILE
-AS $$ SELECT state + x + coalesce(sum_v(NULL::v), 0)
-$$;
-
 CREATE OR REPLACE FUNCTION total_v()
 RETURNS integer
 LANGUAGE sql
@@ -217,12 +205,6 @@ LANGUAGE sql
 VOLATILE
 AS $$ SELECT sum_with_v(id) FROM t
 $$;
-
-CREATE AGGREGATE chain_agg(integer) (
-    SFUNC = chain_sfunc,
-    STYPE = integer,
-    INITCOND = '0'
-);
 
 CREATE OR REPLACE VIEW v_total AS
  SELECT sum_v(v.*) AS total

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,18 +1,21 @@
-Plan: 6 to add.
+Plan: 10 to add.
 
 Summary by type:
-  functions: 3 to add
-  aggregates: 1 to add
+  functions: 5 to add
+  aggregates: 2 to add
   tables: 1 to add
-  views: 1 to add
+  views: 2 to add
 
 Functions:
+  + acc_with_v
   + count_v
+  + get_total
   + touch_t
   + v_sfunc
 
 Aggregates:
   + sum_v
+  + sum_with_v
 
 Tables:
   + t
@@ -20,6 +23,7 @@ Tables:
 
 Views:
   + v
+  + v_total
 
 DDL to be executed:
 --------------------------------------------------
@@ -47,6 +51,16 @@ CREATE OR REPLACE VIEW v AS
     name
    FROM t;
 
+CREATE OR REPLACE FUNCTION acc_with_v(
+    state bigint,
+    x integer
+)
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT state + x + (SELECT count(*) FROM v)
+$$;
+
 CREATE OR REPLACE FUNCTION count_v()
 RETURNS bigint
 LANGUAGE sql
@@ -69,3 +83,20 @@ CREATE AGGREGATE sum_v(v) (
     STYPE = integer,
     INITCOND = '0'
 );
+
+CREATE AGGREGATE sum_with_v(integer) (
+    SFUNC = acc_with_v,
+    STYPE = bigint,
+    INITCOND = '0'
+);
+
+CREATE OR REPLACE VIEW v_total AS
+ SELECT sum_v(v.*) AS total
+   FROM v;
+
+CREATE OR REPLACE FUNCTION get_total()
+RETURNS SETOF v_total
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT * FROM v_total
+$$;

--- a/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
+++ b/testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view/plan.txt
@@ -1,15 +1,17 @@
-Plan: 21 to add.
+Plan: 23 to add.
 
 Summary by type:
-  functions: 11 to add
+  functions: 13 to add
   aggregates: 5 to add
   tables: 1 to add
   views: 4 to add
 
 Functions:
   + acc_with_v
+  + count_list_v
   + count_my_view
   + count_only_v
+  + count_paren_v
   + count_spaced_v
   + count_v
   + get_total
@@ -80,6 +82,13 @@ VOLATILE
 AS $$ SELECT state + x + (SELECT count(*) FROM v)
 $$;
 
+CREATE OR REPLACE FUNCTION count_list_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM t, v
+$$;
+
 CREATE OR REPLACE FUNCTION count_my_view()
 RETURNS bigint
 LANGUAGE sql
@@ -92,6 +101,13 @@ RETURNS bigint
 LANGUAGE sql
 VOLATILE
 AS $$ SELECT count(*) FROM ONLY v
+$$;
+
+CREATE OR REPLACE FUNCTION count_paren_v()
+RETURNS bigint
+LANGUAGE sql
+VOLATILE
+AS $$ SELECT count(*) FROM ONLY (v)
 $$;
 
 CREATE OR REPLACE FUNCTION count_spaced_v()


### PR DESCRIPTION
## Summary

Follow-up to #581, covering the two remaining cases from #580 that live in the diff package rather than the multi-file formatter. Both reproduced in single-file dump and therefore in `plan`/`apply` against an empty database.

- **Aggregate over a view row type.** An aggregate whose argument, state, or return type names a new view was emitted before the view, and before its own transition function when that function takes the row type. Aggregates with a view dependency are now partitioned out and created after the view-dependent functions, with the same deferred-view handling (issue #414 path) that functions already have.
- **SQL-language function body querying a view.** `functionReferencesNewView` was signature-only. It now also scans the body for SQL-language functions, reusing the existing `tableRefPattern` through a shared `bodyReferencesRelation` helper that `functionReferencesNewTable` uses as well. Other languages stay signature-only on purpose: plpgsql bodies are not validated against relations at creation, and triggers are created before views, so treating body mentions as dependencies would push trigger functions past the triggers that call them. The test case includes exactly that plpgsql trigger function to pin the behavior.

Fixing the aggregate order exposed a pre-existing round-trip bug that the apply harness caught: aggregate type strings were never stripped of the aggregate's own schema prefix, so an aggregate over a relation row type inspected as `sum_v(public.v)` on one side and `sum_v(v)` on the other and was dropped and recreated on every plan. `buildAggregates` now strips the prefix from the search_path-dependent fields `Arguments`, `Signature`, and `ReturnType`, mirroring what function parameters do via `stripSameSchemaPrefix`. State types are left as the catalog query qualifies them, since the diff layer strips or keeps that prefix for `--qualify-schema`.

Fixes #580

## Test plan

- New `testdata/diff/dependency/issue_580_aggregate_and_sql_body_to_view` covering a SQL function querying a view, a plpgsql trigger function mentioning a view, and an aggregate over the view row type with a row-type transition function. Fails before the fix with `relation "v" does not exist`; after the ordering fix it then failed the idempotency check until the inspector fix; now passes.
- `TestDumpCommand_Issue580MultiFileIncludeOrder` extended with both scenarios and asserts view before function, view before transition function, transition function before aggregate.
- Passing locally: full `TestDiffFromFiles`, `TestPlanAndApply` for `dependency/`, `create_aggregate/`, `create_function/`, and `TestDumpCommand_Sakila`.

```bash
PGSCHEMA_TEST_FILTER="dependency/issue_580_aggregate_and_sql_body_to_view" go test -v ./cmd -run TestPlanAndApply
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
