### PR TITLE
fix: mirror target extensions into the embedded plan database (#584)

### DIFF
--- a/cmd/plan/extension_integration_test.go
+++ b/cmd/plan/extension_integration_test.go
@@ -19,9 +19,11 @@ import (
 // throwaway database first — pinned to the same schema as on the target so the
 // diff sees identical type qualification (issue #518).
 //
-// Three placements are covered, each a different mapping into the plan database:
+// Four placements are covered, each a different mapping into the plan database:
 //   - citext in public:          installed into public as-is
 //   - hstore in a side schema:   the side schema is created, then the extension
+//   - seg in pg_catalog:         installed there directly; the system schema
+//     cannot be created (reserved pg_ prefix) but always exists
 //   - ltree in the managed schema: mapped to the temporary schema, since that is
 //     where the managed schema's objects live during plan
 func TestEmbeddedPlanDB_InstallsTargetExtensions(t *testing.T) {
@@ -40,10 +42,12 @@ func TestEmbeddedPlanDB_InstallsTargetExtensions(t *testing.T) {
 		CREATE SCHEMA app;
 		CREATE EXTENSION citext SCHEMA public;
 		CREATE EXTENSION hstore SCHEMA exts;
+		CREATE EXTENSION seg SCHEMA pg_catalog;
 		CREATE EXTENSION ltree SCHEMA app;
 
 		CREATE TABLE public.users (id integer PRIMARY KEY, email citext NOT NULL);
 		CREATE TABLE public.products (id integer PRIMARY KEY, attrs exts.hstore);
+		CREATE TABLE public.ranges (id integer PRIMARY KEY, r seg);
 		CREATE TABLE app.paths (id integer PRIMARY KEY, path app.ltree NOT NULL);
 	`)
 	require.NoError(t, err)
@@ -71,6 +75,7 @@ func TestEmbeddedPlanDB_InstallsTargetExtensions(t *testing.T) {
 		run(t, "public", `
 			CREATE TABLE users (id integer PRIMARY KEY, email citext NOT NULL);
 			CREATE TABLE products (id integer PRIMARY KEY, attrs exts.hstore);
+			CREATE TABLE ranges (id integer PRIMARY KEY, r seg);
 		`)
 	})
 

--- a/cmd/plan/extension_integration_test.go
+++ b/cmd/plan/extension_integration_test.go
@@ -1,0 +1,82 @@
+package plan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pgplex/pgschema/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbeddedPlanDB_InstallsTargetExtensions verifies that the embedded plan
+// database mirrors the extensions installed on the target database (issue #584).
+//
+// pgschema does not manage extensions (they are database-level objects), so a
+// dump never emits CREATE EXTENSION. The desired-state SQL therefore references
+// extension types that only exist if plan installs the extension into its
+// throwaway database first — pinned to the same schema as on the target so the
+// diff sees identical type qualification (issue #518).
+//
+// Three placements are covered, each a different mapping into the plan database:
+//   - citext in public:          installed into public as-is
+//   - hstore in a side schema:   the side schema is created, then the extension
+//   - ltree in the managed schema: mapped to the temporary schema, since that is
+//     where the managed schema's objects live during plan
+func TestEmbeddedPlanDB_InstallsTargetExtensions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	targetDB := testutil.SetupPostgres(t)
+	defer targetDB.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, targetDB)
+	defer conn.Close()
+
+	_, err := conn.ExecContext(ctx, `
+		CREATE SCHEMA exts;
+		CREATE SCHEMA app;
+		CREATE EXTENSION citext SCHEMA public;
+		CREATE EXTENSION hstore SCHEMA exts;
+		CREATE EXTENSION ltree SCHEMA app;
+
+		CREATE TABLE public.users (id integer PRIMARY KEY, email citext NOT NULL);
+		CREATE TABLE public.products (id integer PRIMARY KEY, attrs exts.hstore);
+		CREATE TABLE app.paths (id integer PRIMARY KEY, path app.ltree NOT NULL);
+	`)
+	require.NoError(t, err)
+
+	run := func(t *testing.T, schema, desiredSQL string) {
+		t.Helper()
+		dir := t.TempDir()
+		file := filepath.Join(dir, "schema.sql")
+		require.NoError(t, os.WriteFile(file, []byte(desiredSQL), 0644))
+
+		config := &PlanConfig{
+			Host: host, Port: port, DB: dbname, User: user, Password: password,
+			Schema: schema, File: file, ApplicationName: "pgschema-test", ConfigDir: dir,
+		}
+		provider, err := CreateDesiredStateProvider(config)
+		require.NoError(t, err)
+		defer provider.Stop()
+
+		p, err := GeneratePlan(config, provider)
+		require.NoError(t, err, "plan must succeed without CREATE EXTENSION in the desired state")
+		require.False(t, p.HasAnyChanges(), "desired state matches target; plan should be empty, got:\n%s", p.HumanColored(false))
+	}
+
+	t.Run("extension in public", func(t *testing.T) {
+		run(t, "public", `
+			CREATE TABLE users (id integer PRIMARY KEY, email citext NOT NULL);
+			CREATE TABLE products (id integer PRIMARY KEY, attrs exts.hstore);
+		`)
+	})
+
+	t.Run("extension in managed schema", func(t *testing.T) {
+		run(t, "app", `
+			CREATE TABLE paths (id integer PRIMARY KEY, path ltree NOT NULL);
+		`)
+	})
+}

--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -239,13 +239,15 @@ func CreateDesiredStateProvider(config *PlanConfig) (postgres.DesiredStateProvid
 		return postgres.NewExternalDatabase(externalConfig)
 	}
 
-	// Otherwise, use embedded PostgreSQL
-	return CreateEmbeddedPostgresForPlan(config, pgVersion)
+	// Otherwise, use embedded PostgreSQL, mirroring the target's extensions (issue #584)
+	return CreateEmbeddedPostgresForPlan(config, pgVersion, targetExtensions)
 }
 
 // CreateEmbeddedPostgresForPlan creates a temporary embedded PostgreSQL instance
 // for validating the desired state schema. The instance should be stopped by the caller.
-func CreateEmbeddedPostgresForPlan(config *PlanConfig, pgVersion postgres.PostgresVersion) (*postgres.EmbeddedPostgres, error) {
+// targetExtensions (name -> schema) are installed into the instance before the
+// desired state is applied so extension types resolve without CREATE EXTENSION.
+func CreateEmbeddedPostgresForPlan(config *PlanConfig, pgVersion postgres.PostgresVersion, targetExtensions map[string]string) (*postgres.EmbeddedPostgres, error) {
 	if config.User == "" {
 		return nil, fmt.Errorf("target database user must not be empty when creating embedded postgres")
 	}
@@ -256,10 +258,11 @@ func CreateEmbeddedPostgresForPlan(config *PlanConfig, pgVersion postgres.Postgr
 	// This ensures ALTER DEFAULT PRIVILEGES FOR ROLE <user> works correctly
 	// and that implicit owner roles match the target database. (issue #303)
 	embeddedConfig := &postgres.EmbeddedPostgresConfig{
-		Version:  pgVersion,
-		Database: "pgschema_temp",
-		Username: config.User,
-		Password: "pgschema",
+		Version:    pgVersion,
+		Database:   "pgschema_temp",
+		Username:   config.User,
+		Password:   "pgschema",
+		Extensions: targetExtensions,
 	}
 	embeddedPG, err := postgres.StartEmbeddedPostgres(embeddedConfig)
 	if err != nil {

--- a/docs/cli/plan-db.mdx
+++ b/docs/cli/plan-db.mdx
@@ -65,19 +65,21 @@ pgschema apply \
 
 pgschema does not manage extensions, so `dump` never emits `CREATE EXTENSION` and you should not add it to your schema files. Instead, the plan database must already have the extensions your schema uses, in the same schema as on the target.
 
-The default embedded plan database handles this for you: it installs every extension found on the target database before applying your schema. This covers all extensions bundled with PostgreSQL (`hstore`, `pg_trgm`, `citext`, `uuid-ossp`, `btree_gist`, ...). Third-party extensions such as `postgis` or `pgvector` are not bundled, so for those you need an external plan database with the extension installed first:
+The default embedded plan database handles this for you: it installs every extension found on the target database before applying your schema. This covers all extensions bundled with PostgreSQL (`hstore`, `pg_trgm`, `citext`, `uuid-ossp`, `btree_gist`, ...). Third-party extensions such as `postgis` or `pgvector` are not bundled, so for those you need an external plan database.
+
+An external plan database is not mirrored automatically: install every extension your schema uses yourself, bundled ones included, in the same schema as on the target:
 
 ```sql
 -- In your plan database, install required extensions
+CREATE EXTENSION IF NOT EXISTS hstore;
 CREATE EXTENSION IF NOT EXISTS postgis;
-CREATE EXTENSION IF NOT EXISTS vector;
 ```
 
 Then run plan or apply with the external database:
 
 ```bash
 # Install extensions in plan database
-psql -h localhost -U postgres -d pgschema_plan -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+psql -h localhost -U postgres -d pgschema_plan -c "CREATE EXTENSION IF NOT EXISTS hstore; CREATE EXTENSION IF NOT EXISTS postgis;"
 
 # Now run plan - it will work because extensions are available
 pgschema plan \

--- a/docs/cli/plan-db.mdx
+++ b/docs/cli/plan-db.mdx
@@ -14,7 +14,7 @@ By default, the `plan` command (and `apply` command in File Mode) spins up a tem
 
 Use an external database for plan generation when:
 
-- Your schema uses **PostgreSQL extensions** (like `hstore`, `postgis`, `uuid-ossp`, etc.) - The embedded database doesn't have extensions pre-installed, causing plan generation to fail with "type does not exist" errors ([#121](https://github.com/pgplex/pgschema/issues/121))
+- Your schema uses **third-party PostgreSQL extensions** (like `postgis` or `pgvector`) - The embedded database automatically mirrors every extension installed on the target, but only extensions bundled with PostgreSQL (contrib: `hstore`, `pg_trgm`, `citext`, `uuid-ossp`, etc.) are available to it. Anything else causes plan generation to fail with "type does not exist" errors ([#121](https://github.com/pgplex/pgschema/issues/121), [#584](https://github.com/pgplex/pgschema/issues/584))
 - Your schema has **cross-schema foreign key references** to tables you do not manage (for example Supabase `auth.users`) - If the referenced table exists on the target database, [ignore that schema or table](/cli/ignore) and pgschema stubs it automatically during plan (embedded postgres is enough). Use the fallbacks below only when the table is missing on target ([#122](https://github.com/pgplex/pgschema/issues/122), [#548](https://github.com/pgplex/pgschema/issues/548))
 
 ### How It Works
@@ -63,13 +63,14 @@ pgschema apply \
 
 ### Using PostgreSQL Extensions
 
-If your schema uses extensions like `hstore`, `postgis`, or `uuid-ossp`, you need to install them in the plan database first:
+pgschema does not manage extensions, so `dump` never emits `CREATE EXTENSION` and you should not add it to your schema files. Instead, the plan database must already have the extensions your schema uses, in the same schema as on the target.
+
+The default embedded plan database handles this for you: it installs every extension found on the target database before applying your schema. This covers all extensions bundled with PostgreSQL (`hstore`, `pg_trgm`, `citext`, `uuid-ossp`, `btree_gist`, ...). Third-party extensions such as `postgis` or `pgvector` are not bundled, so for those you need an external plan database with the extension installed first:
 
 ```sql
 -- In your plan database, install required extensions
-CREATE EXTENSION IF NOT EXISTS hstore;
 CREATE EXTENSION IF NOT EXISTS postgis;
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS vector;
 ```
 
 Then run plan or apply with the external database:

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -11,10 +11,12 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/pgplex/pgschema/cmd/util"
+	"github.com/pgplex/pgschema/internal/logger"
 )
 
 // binariesPath is the path that contains the Postgres binaries.
@@ -37,7 +39,8 @@ type EmbeddedPostgres struct {
 	username    string
 	password    string
 	runtimePath string
-	tempSchema  string // temporary schema name with timestamp for uniqueness
+	tempSchema  string            // temporary schema name with timestamp for uniqueness
+	extensions  map[string]string // target extensions to mirror, name -> schema (issue #584)
 }
 
 // EmbeddedPostgresConfig holds configuration for starting embedded PostgreSQL
@@ -46,6 +49,11 @@ type EmbeddedPostgresConfig struct {
 	Database string
 	Username string
 	Password string
+	// Extensions maps extension name to its installation schema on the target
+	// database. ApplySchema installs each one into the embedded database before
+	// applying the desired state, so desired-state SQL can reference extension
+	// types without a CREATE EXTENSION statement (issue #584). Optional.
+	Extensions map[string]string
 }
 
 // DetectPostgresVersionAndExtensionsFromDB connects to a database and detects its
@@ -157,6 +165,7 @@ func StartEmbeddedPostgres(config *EmbeddedPostgresConfig) (*EmbeddedPostgres, e
 		password:    config.Password,
 		runtimePath: runtimePath,
 		tempSchema:  tempSchema,
+		extensions:  config.Extensions,
 	}, nil
 }
 
@@ -233,6 +242,11 @@ func (ep *EmbeddedPostgres) ApplySchema(ctx context.Context, schema string, sql 
 		return fmt.Errorf("failed to create temporary schema %s: %w", ep.tempSchema, err)
 	}
 
+	// Mirror the target's extensions so extension types resolve (issue #584)
+	if err := ep.installTargetExtensions(ctx, conn, schema); err != nil {
+		return err
+	}
+
 	// Set search_path to the temporary schema, with public as fallback
 	// for resolving extension types installed in public schema (issue #197)
 	setSearchPathSQL := fmt.Sprintf("SET search_path TO \"%s\", public", ep.tempSchema)
@@ -267,11 +281,54 @@ func (ep *EmbeddedPostgres) ApplySchema(ctx context.Context, schema string, sql 
 	// Note: Desired state SQL should never contain operations like CREATE INDEX CONCURRENTLY
 	// that cannot run in transactions. Those are migration details, not state declarations.
 	if err := ExecuteSchemaSQL(ctx, conn, schemaAgnosticSQL, schema); err != nil {
-		enhanced := hintExtensionDependency(err, "this schema may depend on a PostgreSQL extension, which the embedded plan database cannot provide. Use an external plan database with the extension installed (--plan-host), see https://www.pgschema.com/cli/plan-db")
+		enhanced := hintExtensionDependency(err, "this schema may depend on a PostgreSQL extension that the embedded plan database cannot provide. Extensions installed on the target database are mirrored automatically, but only those bundled with PostgreSQL (contrib) are available; for third-party extensions such as postgis or pgvector, use an external plan database with the extension installed (--plan-host), see https://www.pgschema.com/cli/plan-db")
 		enhanced = hintCrossSchemaReference(enhanced, "this schema may reference objects in another schema that the embedded plan database does not have. If the table exists on the target database, add it to .pgschemaignore ([schemas] or schema-qualified [tables] pattern, e.g. auth or auth.users), see https://www.pgschema.com/cli/ignore. Otherwise add a stub CREATE SCHEMA/TABLE in your desired SQL, or use an external plan database (--plan-host), see https://www.pgschema.com/cli/plan-db")
 		return fmt.Errorf("failed to apply schema SQL to temporary schema %s: %w", ep.tempSchema, enhanced)
 	}
 
+	return nil
+}
+
+// installTargetExtensions mirrors the target database's extensions into the
+// embedded plan database. pgschema does not manage extensions (they are
+// database-level objects), so a dump never emits CREATE EXTENSION; without this
+// step, desired-state SQL that references an extension type fails with
+// "type does not exist" (issue #584).
+//
+// Each extension is pinned to the schema it occupies on the target so that type
+// qualification matches on both sides of the diff (issue #518). An extension
+// living in the managed schema is installed into the temporary schema, which
+// stands in for the managed schema during plan. Extensions the embedded binary
+// does not bundle (e.g. postgis, pgvector) are skipped with a warning; if the
+// desired state actually needs one, the later apply error points at --plan-host.
+func (ep *EmbeddedPostgres) installTargetExtensions(ctx context.Context, conn *sql.Conn, managedSchema string) error {
+	names := make([]string, 0, len(ep.extensions))
+	for name := range ep.extensions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		schema := ep.extensions[name]
+		switch {
+		case name == "plpgsql", schema == "pg_catalog":
+			// Preinstalled or system-owned; nothing to mirror.
+			continue
+		case schema == managedSchema:
+			schema = ep.tempSchema
+		default:
+			createSchemaSQL := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoteIdent(schema))
+			if _, err := util.ExecContextWithLogging(ctx, conn, createSchemaSQL, "create schema for target extension"); err != nil {
+				return fmt.Errorf("failed to create schema %s for extension %s: %w", schema, name, err)
+			}
+		}
+
+		createExtSQL := fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", quoteIdent(name), quoteIdent(schema))
+		if _, err := util.ExecContextWithLogging(ctx, conn, createExtSQL, "install target extension"); err != nil {
+			logger.Get().Warn("extension installed on the target database is not available in the embedded plan database; if the schema depends on it, use an external plan database (--plan-host)",
+				"extension", name, "error", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -311,11 +312,16 @@ func (ep *EmbeddedPostgres) installTargetExtensions(ctx context.Context, conn *s
 	for _, name := range names {
 		schema := ep.extensions[name]
 		switch {
-		case name == "plpgsql", schema == "pg_catalog":
-			// Preinstalled or system-owned; nothing to mirror.
+		case name == "plpgsql":
+			// Preinstalled in every database; nothing to mirror.
 			continue
 		case schema == managedSchema:
 			schema = ep.tempSchema
+		case strings.HasPrefix(schema, "pg_"):
+			// System schemas (pg_catalog etc.) always exist and cannot be
+			// created — the pg_ prefix is reserved, even with IF NOT EXISTS.
+			// Extensions installed there (adminpack, or a relocatable one the
+			// user pinned to pg_catalog) still need mirroring.
 		default:
 			createSchemaSQL := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoteIdent(schema))
 			if _, err := util.ExecContextWithLogging(ctx, conn, createSchemaSQL, "create schema for target extension"); err != nil {

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -303,14 +303,10 @@ func (ep *EmbeddedPostgres) ApplySchema(ctx context.Context, schema string, sql 
 // does not bundle (e.g. postgis, pgvector) are skipped with a warning; if the
 // desired state actually needs one, the later apply error points at --plan-host.
 func (ep *EmbeddedPostgres) installTargetExtensions(ctx context.Context, conn *sql.Conn, managedSchema string) error {
-	names := make([]string, 0, len(ep.extensions))
-	for name := range ep.extensions {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		schema := ep.extensions[name]
+	// Resolve each extension's schema in the plan database and make sure it exists.
+	schemas := make(map[string]string, len(ep.extensions))
+	pending := make([]string, 0, len(ep.extensions))
+	for name, schema := range ep.extensions {
 		switch {
 		case name == "plpgsql":
 			// Preinstalled in every database; nothing to mirror.
@@ -328,14 +324,54 @@ func (ep *EmbeddedPostgres) installTargetExtensions(ctx context.Context, conn *s
 				return fmt.Errorf("failed to create schema %s for extension %s: %w", schema, name, err)
 			}
 		}
+		schemas[name] = schema
+		pending = append(pending, name)
+	}
+	sort.Strings(pending)
 
-		createExtSQL := fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", quoteIdent(name), quoteIdent(schema))
-		if _, err := util.ExecContextWithLogging(ctx, conn, createExtSQL, "install target extension"); err != nil {
+	unavailable := installUntilFixpoint(pending, func(name string) error {
+		createExtSQL := fmt.Sprintf("CREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s", quoteIdent(name), quoteIdent(schemas[name]))
+		_, err := util.ExecContextWithLogging(ctx, conn, createExtSQL, "install target extension")
+		return err
+	})
+	for _, name := range pending {
+		if err, ok := unavailable[name]; ok {
 			logger.Get().Warn("extension installed on the target database is not available in the embedded plan database; if the schema depends on it, use an external plan database (--plan-host)",
 				"extension", name, "error", err)
 		}
 	}
 	return nil
+}
+
+// installUntilFixpoint calls install for every name, then retries the failures
+// after each pass until a pass installs nothing more. It returns the last error
+// for each name that never succeeded.
+//
+// Extensions can require others (hstore_plperl needs hstore and plperl), and the
+// required one may sort later, so a single ordered pass is not enough. Rather
+// than reconstructing the dependency graph from the target, keep retrying: each
+// pass installs at least the prerequisites whose own prerequisites are met, so
+// the loop terminates within len(names) passes. CASCADE is not an option — it
+// would install prerequisites into the wrong schema.
+func installUntilFixpoint(names []string, install func(name string) error) map[string]error {
+	lastErr := make(map[string]error)
+	pending := names
+	for len(pending) > 0 {
+		var failed []string
+		for _, name := range pending {
+			if err := install(name); err != nil {
+				failed = append(failed, name)
+				lastErr[name] = err
+			} else {
+				delete(lastErr, name)
+			}
+		}
+		if len(failed) == len(pending) {
+			break
+		}
+		pending = failed
+	}
+	return lastErr
 }
 
 // findAvailablePort finds an available TCP port for PostgreSQL to use

--- a/internal/postgres/embedded_extensions_test.go
+++ b/internal/postgres/embedded_extensions_test.go
@@ -1,0 +1,62 @@
+package postgres
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestInstallUntilFixpoint simulates extension prerequisites that sort after
+// their dependents (hstore_plperl requires plperl), which a single alphabetical
+// pass cannot install (issue #584 review).
+func TestInstallUntilFixpoint(t *testing.T) {
+	requires := map[string][]string{
+		"hstore_plperl": {"hstore", "plperl"},
+		"bool_plperl":   {"plperl"},
+		"postgis":       {"libpostgis"}, // never satisfiable: not bundled
+	}
+	installed := map[string]bool{}
+	var calls []string
+
+	install := func(name string) error {
+		calls = append(calls, name)
+		for _, dep := range requires[name] {
+			if !installed[dep] {
+				return errors.New("required extension " + dep + " is not installed")
+			}
+		}
+		installed[name] = true
+		return nil
+	}
+
+	// Alphabetical, as installTargetExtensions feeds it.
+	names := []string{"bool_plperl", "hstore", "hstore_plperl", "plperl", "postgis"}
+	unavailable := installUntilFixpoint(names, install)
+
+	for _, name := range []string{"bool_plperl", "hstore", "hstore_plperl", "plperl"} {
+		if !installed[name] {
+			t.Errorf("%s should have been installed once its prerequisites were", name)
+		}
+		if _, ok := unavailable[name]; ok {
+			t.Errorf("%s should not be reported unavailable", name)
+		}
+	}
+	if err, ok := unavailable["postgis"]; !ok {
+		t.Errorf("postgis should be reported unavailable")
+	} else if err == nil {
+		t.Errorf("unavailable entry should carry the last error")
+	}
+
+	// Pass 1: 5 calls (2 fail on plperl, postgis fails). Pass 2: 3 retries (postgis
+	// fails). Pass 3: postgis only, still fails, no progress -> stop.
+	if len(calls) != 9 {
+		t.Errorf("expected 9 install calls (5 + 3 + 1), got %d: %v", len(calls), calls)
+	}
+}
+
+func TestInstallUntilFixpoint_Empty(t *testing.T) {
+	called := false
+	unavailable := installUntilFixpoint(nil, func(string) error { called = true; return nil })
+	if called || len(unavailable) != 0 {
+		t.Errorf("no names should mean no calls and nothing unavailable")
+	}
+}


### PR DESCRIPTION
## Summary

`pgschema dump` never emits `CREATE EXTENSION` (extensions are database-level and unmanaged), so the embedded plan database started with none of the target's extensions. Any schema referencing an extension type — `citext`, `hstore`, `pg_trgm`, … — failed at plan time with `type "x" does not exist`, forcing users to hand-edit `CREATE EXTENSION` into their dump. Yet every contrib extension is bundled with the embedded binary; the gap was purely that nothing installed them.

`plan` already reads the target's installed extensions and their schemas (for the `--plan-host` consistency check from #518) and then discarded that map on the embedded path. This PR threads it into `EmbeddedPostgres` and installs each extension in `ApplySchema`, before the desired state:

- pinned `WITH SCHEMA` to the target's schema, so type qualification matches on both sides of the diff (#518 stays correct)
- an extension living in the managed schema is installed into the temporary schema, which stands in for it during plan
- extensions the binary does not bundle (postgis, pgvector) are skipped with a warning; the existing apply-time hint still routes to `--plan-host`

Also corrects the hint text and `plan-db.mdx`, which claimed the embedded database has no extensions at all — only third-party ones need an external plan database.

Fixes #584. The roles half of that issue is a duplicate of #450 and is tracked there.

## Test plan

New `TestEmbeddedPlanDB_InstallsTargetExtensions` (`cmd/plan/extension_integration_test.go`) sets up a target with `citext` in `public`, `hstore` in a side schema, and `ltree` inside a managed schema `app`, then plans a desired state that references those types with no `CREATE EXTENSION`. It fails before this change with the reporter's exact error and passes after, asserting an empty plan for both the `public` and `app` managed-schema cases.

```bash
go test ./cmd/plan -run TestEmbeddedPlanDB_InstallsTargetExtensions -v
```

Also ran locally: all `cmd/plan` integration tests (`TestPlanCommand_*`, `TestExternalDatabase_*`, `TestPlanConfigDataConsistency`) and `cmd/apply` file-mode tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
