### PR TITLE
fix: stub referenced roles in the plan database (#450)

### DIFF
--- a/cmd/plan/plan.go
+++ b/cmd/plan/plan.go
@@ -316,21 +316,21 @@ func GeneratePlan(config *PlanConfig, provider postgres.DesiredStateProvider) (*
 	}
 
 	ctx := context.Background()
+	targetConnCfg := &util.ConnectionConfig{
+		Host:            config.Host,
+		Port:            config.Port,
+		Database:        config.DB,
+		User:            config.User,
+		Password:        config.Password,
+		SSLMode:         config.SSLMode,
+		ApplicationName: config.ApplicationName,
+	}
 
 	// Clone ignored FK targets from the target database into the plan SQL so
 	// REFERENCES auth.users (and same-schema ignored tables) can apply without
 	// those tables appearing in the desired schema file (issue #548).
 	if ignoreConfig != nil {
-		connCfg := &util.ConnectionConfig{
-			Host:            config.Host,
-			Port:            config.Port,
-			Database:        config.DB,
-			User:            config.User,
-			Password:        config.Password,
-			SSLMode:         config.SSLMode,
-			ApplicationName: config.ApplicationName,
-		}
-		desiredState, err = prependIgnoredTableStubs(ctx, connCfg, ignoreConfig, config.Schema, desiredState)
+		desiredState, err = prependIgnoredTableStubs(ctx, targetConnCfg, ignoreConfig, config.Schema, desiredState)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stub ignored foreign key targets: %w", err)
 		}
@@ -338,20 +338,15 @@ func GeneratePlan(config *PlanConfig, provider postgres.DesiredStateProvider) (*
 
 	// Stub cross-schema partition parents so PARTITION OF references resolve
 	// in the plan database (issue #552).
-	{
-		connCfg := &util.ConnectionConfig{
-			Host:            config.Host,
-			Port:            config.Port,
-			Database:        config.DB,
-			User:            config.User,
-			Password:        config.Password,
-			SSLMode:         config.SSLMode,
-			ApplicationName: config.ApplicationName,
-		}
-		desiredState, err = prependPartitionParentStubs(ctx, connCfg, config.Schema, desiredState)
-		if err != nil {
-			return nil, fmt.Errorf("failed to stub cross-schema partition parents: %w", err)
-		}
+	desiredState, err = prependPartitionParentStubs(ctx, targetConnCfg, config.Schema, desiredState)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stub cross-schema partition parents: %w", err)
+	}
+
+	// Roles are cluster-global and unmanaged: the provider stubs the ones the
+	// schema references, but only roles the target has (issue #450).
+	if err := validateReferencedRoles(ctx, targetConnCfg, desiredState); err != nil {
+		return nil, err
 	}
 
 	// Apply desired state SQL to the provider (embedded postgres or external database)

--- a/cmd/plan/role_external_integration_test.go
+++ b/cmd/plan/role_external_integration_test.go
@@ -1,0 +1,70 @@
+package plan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pgplex/pgschema/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExternalDatabase_StubsReferencedRoles verifies that an external plan
+// database gets stub roles for the schema's grantees, and that Stop drops only
+// the roles pgschema created (issue #450).
+func TestExternalDatabase_StubsReferencedRoles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	targetDB := testutil.SetupPostgres(t)
+	defer targetDB.Stop()
+	planDB := testutil.SetupPostgres(t)
+	defer planDB.Stop()
+
+	targetConn, targetHost, targetPort, targetDatabase, targetUser, targetPassword := testutil.ConnectToPostgres(t, targetDB)
+	defer targetConn.Close()
+	_, err := targetConn.Exec(`
+		CREATE ROLE app_workspace;
+		CREATE ROLE shared_role;
+		CREATE TABLE users (id integer PRIMARY KEY);
+		GRANT SELECT ON users TO app_workspace, shared_role;
+	`)
+	require.NoError(t, err)
+
+	// shared_role already exists on the plan host; app_workspace does not.
+	planConn, planHost, planPort, planDatabase, planUser, planPassword := testutil.ConnectToPostgres(t, planDB)
+	defer planConn.Close()
+	_, err = planConn.Exec("CREATE ROLE shared_role")
+	require.NoError(t, err)
+
+	roleExists := func(name string) bool {
+		var exists bool
+		require.NoError(t, planConn.QueryRow("SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = $1)", name).Scan(&exists))
+		return exists
+	}
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "schema.sql")
+	require.NoError(t, os.WriteFile(file, []byte(`
+		CREATE TABLE users (id integer PRIMARY KEY);
+		GRANT SELECT ON users TO app_workspace, shared_role;
+	`), 0644))
+
+	config := &PlanConfig{
+		Host: targetHost, Port: targetPort, DB: targetDatabase, User: targetUser, Password: targetPassword,
+		Schema: "public", File: file, ApplicationName: "pgschema-test", ConfigDir: dir,
+		PlanDBHost: planHost, PlanDBPort: planPort, PlanDBDatabase: planDatabase, PlanDBUser: planUser, PlanDBPassword: planPassword,
+	}
+	provider, err := CreateDesiredStateProvider(config)
+	require.NoError(t, err)
+
+	p, err := GeneratePlan(config, provider)
+	require.NoError(t, err, "plan must succeed without CREATE ROLE in the desired state")
+	require.False(t, p.HasAnyChanges(), "desired state matches target; plan should be empty, got:\n%s", p.HumanColored(false))
+	require.True(t, roleExists("app_workspace"), "stub role should exist while the provider is alive")
+
+	require.NoError(t, provider.Stop())
+	require.False(t, roleExists("app_workspace"), "stub role must be dropped on Stop")
+	require.True(t, roleExists("shared_role"), "pre-existing role must never be dropped")
+}

--- a/cmd/plan/role_integration_test.go
+++ b/cmd/plan/role_integration_test.go
@@ -1,0 +1,95 @@
+package plan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pgplex/pgschema/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmbeddedPlanDB_StubsReferencedRoles verifies that plan can consume a dump
+// that grants privileges to roles, without the schema file creating those
+// roles (issue #450).
+//
+// Roles are cluster-global and not managed by pgschema, so dump never emits
+// CREATE ROLE. The throwaway plan database therefore has none of them, and
+// every GRANT ... TO <role> used to fail with "role does not exist". plan now
+// stubs each referenced role that exists on the target; a role the target
+// does not have is reported up front instead of failing later at apply.
+func TestEmbeddedPlanDB_StubsReferencedRoles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	targetDB := testutil.SetupPostgres(t)
+	defer targetDB.Stop()
+	conn, host, port, dbname, user, password := testutil.ConnectToPostgres(t, targetDB)
+	defer conn.Close()
+
+	// Every role-bearing statement dump can emit: object GRANT, column GRANT,
+	// policy TO, and ALTER DEFAULT PRIVILEGES with both a grantor and a grantee.
+	_, err := conn.ExecContext(ctx, `
+		CREATE ROLE app_workspace;
+		CREATE ROLE reader;
+
+		CREATE TABLE users (id integer PRIMARY KEY, email text NOT NULL);
+		CREATE SEQUENCE ticket_seq;
+		GRANT SELECT, INSERT ON users TO app_workspace;
+		GRANT SELECT (id) ON users TO reader;
+		GRANT USAGE ON SEQUENCE ticket_seq TO app_workspace;
+		ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+		CREATE POLICY users_self ON users FOR SELECT TO app_workspace USING (true);
+		ALTER DEFAULT PRIVILEGES FOR ROLE app_workspace IN SCHEMA public GRANT SELECT ON TABLES TO reader;
+	`)
+	require.NoError(t, err)
+
+	plan := func(t *testing.T, desiredSQL string) error {
+		t.Helper()
+		dir := t.TempDir()
+		file := filepath.Join(dir, "schema.sql")
+		require.NoError(t, os.WriteFile(file, []byte(desiredSQL), 0644))
+
+		config := &PlanConfig{
+			Host: host, Port: port, DB: dbname, User: user, Password: password,
+			Schema: "public", File: file, ApplicationName: "pgschema-test", ConfigDir: dir,
+		}
+		provider, err := CreateDesiredStateProvider(config)
+		require.NoError(t, err)
+		defer provider.Stop()
+
+		p, err := GeneratePlan(config, provider)
+		if err != nil {
+			return err
+		}
+		require.False(t, p.HasAnyChanges(), "desired state matches target; plan should be empty, got:\n%s", p.HumanColored(false))
+		return nil
+	}
+
+	t.Run("dump round-trips without CREATE ROLE", func(t *testing.T) {
+		err := plan(t, `
+			CREATE TABLE users (id integer PRIMARY KEY, email text NOT NULL);
+			CREATE SEQUENCE ticket_seq;
+			GRANT SELECT, INSERT ON users TO app_workspace;
+			GRANT SELECT (id) ON users TO reader;
+			GRANT USAGE ON SEQUENCE ticket_seq TO app_workspace;
+			ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+			CREATE POLICY users_self ON users FOR SELECT TO app_workspace USING (true);
+			ALTER DEFAULT PRIVILEGES FOR ROLE app_workspace IN SCHEMA public GRANT SELECT ON TABLES TO reader;
+		`)
+		require.NoError(t, err, "plan must succeed without CREATE ROLE in the desired state")
+	})
+
+	t.Run("role missing on target is reported at plan time", func(t *testing.T) {
+		err := plan(t, `
+			CREATE TABLE users (id integer PRIMARY KEY, email text NOT NULL);
+			GRANT SELECT ON users TO ghost_role;
+		`)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "ghost_role")
+		require.Contains(t, err.Error(), "does not exist on the target database")
+	})
+}

--- a/cmd/plan/role_stubs.go
+++ b/cmd/plan/role_stubs.go
@@ -1,0 +1,61 @@
+package plan
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/pgplex/pgschema/cmd/util"
+	"github.com/pgplex/pgschema/internal/postgres"
+	"github.com/pgplex/pgschema/ir"
+)
+
+// validateReferencedRoles rejects desired-state SQL that grants to roles the
+// target database does not have. Roles are cluster-global and not managed by
+// pgschema, so plan stubs the referenced ones in its throwaway database (issue
+// #450) — but stubbing a role the target lacks would only move the failure to
+// apply time, with a worse message.
+func validateReferencedRoles(ctx context.Context, cfg *util.ConnectionConfig, desiredSQL string) error {
+	referenced := postgres.ExtractReferencedRoles(desiredSQL)
+	if len(referenced) == 0 {
+		return nil
+	}
+
+	conn, err := util.Connect(cfg)
+	if err != nil {
+		return fmt.Errorf("connect to check referenced roles: %w", err)
+	}
+	defer conn.Close()
+
+	rows, err := conn.QueryContext(ctx, "SELECT rolname FROM pg_catalog.pg_roles")
+	if err != nil {
+		return fmt.Errorf("query target roles: %w", err)
+	}
+	defer rows.Close()
+	existing := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return fmt.Errorf("scan target role: %w", err)
+		}
+		existing[name] = true
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read target roles: %w", err)
+	}
+
+	var missing []string
+	for _, role := range referenced {
+		if !existing[role] {
+			missing = append(missing, ir.QuoteIdentifier(role))
+		}
+	}
+	switch len(missing) {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("role %s is referenced by the schema but does not exist on the target database; pgschema does not manage roles, create it on the target first, see https://www.pgschema.com/cli/plan-db", missing[0])
+	default:
+		return fmt.Errorf("roles %s are referenced by the schema but do not exist on the target database; pgschema does not manage roles, create them on the target first, see https://www.pgschema.com/cli/plan-db", strings.Join(missing, ", "))
+	}
+}

--- a/docs/cli/plan-db.mdx
+++ b/docs/cli/plan-db.mdx
@@ -112,7 +112,7 @@ pgschema does not manage roles either — they are cluster-global — so `dump` 
 To keep that output usable by `plan`, every role your schema references (`GRANT`/`REVOKE` grantees, `CREATE POLICY ... TO`, `ALTER DEFAULT PRIVILEGES FOR ROLE` grantors) is stubbed in the plan database before your schema is applied:
 
 - **Embedded plan database**: stubs are created in the throwaway instance and vanish with it.
-- **External plan database**: stubs are created on the plan host and dropped on cleanup. Only roles pgschema created are ever dropped; a role that already exists there is left untouched. The plan user needs `CREATEROLE` (or the roles must already exist on the plan host).
+- **External plan database**: stubs are created on the plan host and dropped on cleanup. Only roles pgschema created are ever dropped; a role that already exists there is left untouched. The plan user needs `CREATEROLE` (or the roles must already exist on the plan host). Stub roles are cluster-global, so concurrent plans sharing one plan host can contend on them — give each concurrent run its own plan host, or pre-create the roles there.
 
 A referenced role must exist on the **target** database. If it does not, `plan` fails up front with `role "x" is referenced by the schema but does not exist on the target database`, because `apply` would fail on it anyway — create the role on the target first.
 

--- a/docs/cli/plan-db.mdx
+++ b/docs/cli/plan-db.mdx
@@ -105,6 +105,17 @@ CREATE TABLE products (
 );
 ```
 
+### Roles
+
+pgschema does not manage roles either — they are cluster-global — so `dump` emits `GRANT ... TO app_user` but never `CREATE ROLE app_user`, and you should not add `CREATE ROLE` to your schema files.
+
+To keep that output usable by `plan`, every role your schema references (`GRANT`/`REVOKE` grantees, `CREATE POLICY ... TO`, `ALTER DEFAULT PRIVILEGES FOR ROLE` grantors) is stubbed in the plan database before your schema is applied:
+
+- **Embedded plan database**: stubs are created in the throwaway instance and vanish with it.
+- **External plan database**: stubs are created on the plan host and dropped on cleanup. Only roles pgschema created are ever dropped; a role that already exists there is left untouched. The plan user needs `CREATEROLE` (or the roles must already exist on the plan host).
+
+A referenced role must exist on the **target** database. If it does not, `plan` fails up front with `role "x" is referenced by the schema but does not exist on the target database`, because `apply` would fail on it anyway — create the role on the target first.
+
 ### Handling Cross-Schema Foreign Keys
 
 If your schema has foreign keys that reference tables in other schemas (for example `REFERENCES auth.users`), those referenced objects must exist when `plan` applies your desired-state SQL to its temporary database.

--- a/docs/syntax/unsupported.mdx
+++ b/docs/syntax/unsupported.mdx
@@ -11,6 +11,8 @@ title: "Unsupported"
 - `CREATE TABLESPACE`
 - `CREATE USER`
 
+Roles stay out of your schema files, but you can still grant to them: `plan` stubs every role your schema references (`GRANT`/`REVOKE`, `CREATE POLICY ... TO`, `ALTER DEFAULT PRIVILEGES FOR ROLE`) in its temporary database, provided the role exists on the target database. See [Roles](/cli/plan-db#roles).
+
 ## Database Level Commands
 
 - `CREATE CAST`

--- a/internal/postgres/embedded.go
+++ b/internal/postgres/embedded.go
@@ -248,6 +248,15 @@ func (ep *EmbeddedPostgres) ApplySchema(ctx context.Context, schema string, sql 
 		return err
 	}
 
+	// Stub the roles the desired state grants to, so GRANT/POLICY/DEFAULT
+	// PRIVILEGES statements apply (issue #450). The instance is discarded, so
+	// nothing leaks; plan has already rejected roles missing on the target.
+	for _, role := range ExtractReferencedRoles(sql) {
+		if _, err := createRoleIfMissing(ctx, conn, role); err != nil {
+			return err
+		}
+	}
+
 	// Set search_path to the temporary schema, with public as fallback
 	// for resolving extension types installed in public schema (issue #197)
 	setSearchPathSQL := fmt.Sprintf("SET search_path TO \"%s\", public", ep.tempSchema)

--- a/internal/postgres/external.go
+++ b/internal/postgres/external.go
@@ -200,7 +200,10 @@ func (ed *ExternalDatabase) ApplySchema(ctx context.Context, schema string, sql 
 			continue
 		}
 		var isMember bool
-		if err := conn.QueryRowContext(ctx, "SELECT pg_has_role($1, $2, 'MEMBER')", ed.username, role).Scan(&isMember); err != nil || !isMember {
+		if err := conn.QueryRowContext(ctx, "SELECT pg_has_role($1, $2, 'MEMBER')", ed.username, role).Scan(&isMember); err != nil {
+			return fmt.Errorf("failed to check whether %q is a member of role %q: %w", ed.username, role, err)
+		}
+		if !isMember {
 			return fmt.Errorf("role %q already exists in the plan database and the plan user %q is not a member of it; grant membership manually or use a plan user that is already a member of that role", role, ed.username)
 		}
 	}

--- a/internal/postgres/external.go
+++ b/internal/postgres/external.go
@@ -171,33 +171,38 @@ func (ed *ExternalDatabase) ApplySchema(ctx context.Context, schema string, sql 
 	// so we need to rewrite it to point to the temporary schema (issue #335)
 	schemaAgnosticSQL = replaceSchemaInSearchPath(schemaAgnosticSQL, schema, ed.tempSchema)
 
-	// Create stub roles referenced by ALTER DEFAULT PRIVILEGES FOR ROLE so that
-	// the desired SQL can apply in the plan database without "permission denied"
-	// errors (issue #553). The plan user must be a member of these roles for
-	// PostgreSQL to accept the ALTER DEFAULT PRIVILEGES statement.
-	// Only roles that do not already exist are created and tracked for cleanup.
-	candidateRoles := ExtractDefaultPrivilegeRoles(schemaAgnosticSQL)
-	for _, role := range candidateRoles {
-		var exists bool
-		if err := conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = $1)", role).Scan(&exists); err != nil {
-			return fmt.Errorf("failed to check existence of role %s: %w", role, err)
+	// Stub every role the desired state references so GRANT/POLICY/DEFAULT
+	// PRIVILEGES statements apply in the plan database (issue #450). A
+	// successful CREATE ROLE is the sole proof that a role is ours to drop on
+	// Stop; a pre-existing role is never touched. ALTER DEFAULT PRIVILEGES FOR
+	// ROLE additionally requires the plan user to be a member of the grantor
+	// (issue #553), which we can only arrange for roles we created.
+	adpGrantors := make(map[string]bool)
+	for _, role := range ExtractDefaultPrivilegeRoles(schemaAgnosticSQL) {
+		adpGrantors[role] = true
+	}
+	for _, role := range ExtractReferencedRoles(schemaAgnosticSQL) {
+		created, err := createRoleIfMissing(ctx, conn, role)
+		if err != nil {
+			return err
 		}
-		if exists {
-			var isMember bool
-			if err := conn.QueryRowContext(ctx, "SELECT pg_has_role($1, $2, 'MEMBER')", ed.username, role).Scan(&isMember); err != nil || !isMember {
-				return fmt.Errorf("role %q already exists in the plan database and the plan user %q is not a member of it; grant membership manually or use a plan user that is already a member of that role", role, ed.username)
+		if created {
+			ed.stubRoles = append(ed.stubRoles, role)
+		}
+		if !adpGrantors[role] {
+			continue
+		}
+		if created {
+			grantSQL := fmt.Sprintf("GRANT %s TO %s", quoteIdent(role), quoteIdent(ed.username))
+			if _, err := util.ExecContextWithLogging(ctx, conn, grantSQL, "grant stub role membership"); err != nil {
+				return fmt.Errorf("failed to grant role %s to %s: %w", role, ed.username, err)
 			}
 			continue
 		}
-		createRoleSQL := fmt.Sprintf("CREATE ROLE %s", quoteIdent(role))
-		if _, err := util.ExecContextWithLogging(ctx, conn, createRoleSQL, "create stub role for default privileges"); err != nil {
-			return fmt.Errorf("failed to create stub role %s: %w", role, err)
+		var isMember bool
+		if err := conn.QueryRowContext(ctx, "SELECT pg_has_role($1, $2, 'MEMBER')", ed.username, role).Scan(&isMember); err != nil || !isMember {
+			return fmt.Errorf("role %q already exists in the plan database and the plan user %q is not a member of it; grant membership manually or use a plan user that is already a member of that role", role, ed.username)
 		}
-		grantSQL := fmt.Sprintf("GRANT %s TO %s", quoteIdent(role), quoteIdent(ed.username))
-		if _, err := util.ExecContextWithLogging(ctx, conn, grantSQL, "grant stub role membership"); err != nil {
-			return fmt.Errorf("failed to grant role %s to %s: %w", role, ed.username, err)
-		}
-		ed.stubRoles = append(ed.stubRoles, role)
 	}
 
 	// Execute the SQL directly

--- a/internal/postgres/role_refs.go
+++ b/internal/postgres/role_refs.go
@@ -51,24 +51,34 @@ func ExtractReferencedRoles(sql string) []string {
 		{"revoke", "from"},
 		{"policy", "to"},
 	}
-	walkSQLCode(sql, func(code string) {
-		for stmt := range strings.SplitSeq(code, ";") {
-			for _, c := range clauses {
-				at := indexKeyword(stmt, 0, c.stmt)
-				if at < 0 {
-					continue
-				}
-				at = indexKeyword(stmt, at+len(c.stmt), c.list)
-				if at < 0 {
-					continue
-				}
-				for _, role := range parseRoleList(stmt, at+len(c.list)) {
-					add(role)
-				}
+	for stmt := range strings.SplitSeq(codeOnly(sql), ";") {
+		for _, c := range clauses {
+			at := indexKeyword(stmt, 0, c.stmt)
+			if at < 0 {
+				continue
+			}
+			at = indexKeyword(stmt, at+len(c.stmt), c.list)
+			if at < 0 {
+				continue
+			}
+			for _, role := range parseRoleList(stmt, at+len(c.list)) {
+				add(role)
 			}
 		}
-	})
+	}
 	return out
+}
+
+// codeOnly returns sql with string literals, comments, and dollar-quoted
+// bodies replaced by a space, so a statement stays contiguous even when a
+// comment sits between its keywords (GRANT ... TO /* why */ app_user).
+func codeOnly(sql string) string {
+	var b strings.Builder
+	walkSQLCode(sql, func(code string) {
+		b.WriteString(code)
+		b.WriteByte(' ')
+	})
+	return b.String()
 }
 
 // parseRoleList parses a comma-separated list of role specifications starting
@@ -114,8 +124,8 @@ func createRoleIfMissing(ctx context.Context, conn *sql.Conn, role string) (bool
 			if qerr := conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = $1)", role).Scan(&exists); qerr == nil && exists {
 				return false, nil
 			}
-			return false, fmt.Errorf("failed to create stub role %s: %w\nHint: the plan database user needs CREATEROLE to stub roles referenced by the schema; grant it, or create the role in the plan database first", role, err)
+			return false, fmt.Errorf("failed to create stub role %q: %w\nHint: the plan database user needs CREATEROLE to stub roles referenced by the schema; grant it, or create the role in the plan database first", role, err)
 		}
 	}
-	return false, fmt.Errorf("failed to create stub role %s: %w", role, err)
+	return false, fmt.Errorf("failed to create stub role %q: %w", role, err)
 }

--- a/internal/postgres/role_refs.go
+++ b/internal/postgres/role_refs.go
@@ -1,0 +1,121 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/pgplex/pgschema/cmd/util"
+)
+
+// pseudoRoles are grantee keywords that never name a real role.
+var pseudoRoles = map[string]bool{
+	"public":       true,
+	"current_user": true,
+	"current_role": true,
+	"session_user": true,
+}
+
+// ExtractReferencedRoles returns the distinct role names the SQL needs to
+// exist: grantees of GRANT ... TO and REVOKE ... FROM, roles named by
+// CREATE/ALTER POLICY ... TO, and grantors of ALTER DEFAULT PRIVILEGES FOR ROLE.
+// Pseudo-roles (PUBLIC, CURRENT_USER, CURRENT_ROLE, SESSION_USER) and the
+// predefined pg_* roles are excluded. String literals, comments, and
+// dollar-quoted bodies are skipped, so a role created inside a DO block is
+// invisible here — only its later use is (issue #450).
+func ExtractReferencedRoles(sql string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	add := func(role string) {
+		if role == "" || pseudoRoles[role] || strings.HasPrefix(role, "pg_") || seen[role] {
+			return
+		}
+		seen[role] = true
+		out = append(out, role)
+	}
+
+	for _, role := range ExtractDefaultPrivilegeRoles(sql) {
+		add(role)
+	}
+
+	// Each clause pairs a statement keyword with the keyword that introduces
+	// its role list. Searching within a single statement (split on ';') keeps
+	// one GRANT's TO from being matched to the next statement's, and lets
+	// REVOKE GRANT OPTION FOR ... FROM find no TO after its GRANT and fall
+	// through to the REVOKE rule.
+	clauses := []struct{ stmt, list string }{
+		{"grant", "to"},
+		{"revoke", "from"},
+		{"policy", "to"},
+	}
+	walkSQLCode(sql, func(code string) {
+		for stmt := range strings.SplitSeq(code, ";") {
+			for _, c := range clauses {
+				at := indexKeyword(stmt, 0, c.stmt)
+				if at < 0 {
+					continue
+				}
+				at = indexKeyword(stmt, at+len(c.stmt), c.list)
+				if at < 0 {
+					continue
+				}
+				for _, role := range parseRoleList(stmt, at+len(c.list)) {
+					add(role)
+				}
+			}
+		}
+	})
+	return out
+}
+
+// parseRoleList parses a comma-separated list of role specifications starting
+// at i, e.g. `app_user, "Reader", GROUP admins WITH GRANT OPTION` yields the
+// three names. It stops at the first token that does not continue the list.
+func parseRoleList(s string, i int) []string {
+	var roles []string
+	for {
+		i = skipSpace(s, i)
+		if hasKeywordAt(s, i, "group") {
+			i = skipSpace(s, i+len("group"))
+		}
+		role, next, ok := parseIdent(s, i)
+		if !ok {
+			return roles
+		}
+		roles = append(roles, role)
+		i = skipSpace(s, next)
+		if i >= len(s) || s[i] != ',' {
+			return roles
+		}
+		i++
+	}
+}
+
+// createRoleIfMissing creates a stub role and reports whether this call created
+// it. A successful CREATE ROLE is the only proof of ownership: duplicate_object
+// means the role pre-existed and is not ours to drop. Without CREATEROLE the
+// create is refused before the existence check, so an existing role is then
+// confirmed via pg_roles, while a missing one cannot be stubbed at all.
+func createRoleIfMissing(ctx context.Context, conn *sql.Conn, role string) (bool, error) {
+	_, err := util.ExecContextWithLogging(ctx, conn, "CREATE ROLE "+quoteIdent(role), "create stub role")
+	if err == nil {
+		return true, nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "42710": // duplicate_object
+			return false, nil
+		case "42501": // insufficient_privilege
+			var exists bool
+			if qerr := conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM pg_catalog.pg_roles WHERE rolname = $1)", role).Scan(&exists); qerr == nil && exists {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to create stub role %s: %w\nHint: the plan database user needs CREATEROLE to stub roles referenced by the schema; grant it, or create the role in the plan database first", role, err)
+		}
+	}
+	return false, fmt.Errorf("failed to create stub role %s: %w", role, err)
+}

--- a/internal/postgres/role_refs.go
+++ b/internal/postgres/role_refs.go
@@ -53,11 +53,11 @@ func ExtractReferencedRoles(sql string) []string {
 	}
 	for stmt := range strings.SplitSeq(codeOnly(sql), ";") {
 		for _, c := range clauses {
-			at := indexKeyword(stmt, 0, c.stmt)
+			at := indexKeywordOutsideQuotes(stmt, 0, c.stmt)
 			if at < 0 {
 				continue
 			}
-			at = indexKeyword(stmt, at+len(c.stmt), c.list)
+			at = indexKeywordOutsideQuotes(stmt, at+len(c.stmt), c.list)
 			if at < 0 {
 				continue
 			}
@@ -67,6 +67,25 @@ func ExtractReferencedRoles(sql string) []string {
 		}
 	}
 	return out
+}
+
+// indexKeywordOutsideQuotes is indexKeyword that skips double-quoted
+// identifiers, so an object named "to" or "from" cannot be mistaken for the
+// keyword that introduces a role list.
+func indexKeywordOutsideQuotes(s string, start int, keyword string) int {
+	for i := start; i < len(s); i++ {
+		if s[i] == '"' {
+			if _, next, ok := parseQuotedIdent(s, i); ok {
+				i = next - 1
+				continue
+			}
+			return -1 // unterminated quote: nothing reliable follows
+		}
+		if hasKeywordAt(s, i, keyword) {
+			return i
+		}
+	}
+	return -1
 }
 
 // codeOnly returns sql with string literals, comments, and dollar-quoted

--- a/internal/postgres/role_refs_test.go
+++ b/internal/postgres/role_refs_test.go
@@ -1,0 +1,86 @@
+package postgres
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractReferencedRoles(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "object grant with grant option",
+			sql:  `GRANT SELECT, INSERT ON TABLE users TO app_user WITH GRANT OPTION;`,
+			want: []string{"app_user"},
+		},
+		{
+			name: "multiple grantees and column grant",
+			sql: `GRANT SELECT ON users TO reader, writer;
+			      GRANT UPDATE (email, to_date) ON TABLE users TO editor;`,
+			want: []string{"reader", "writer", "editor"},
+		},
+		{
+			name: "revoke and revoke grant option",
+			sql: `REVOKE INSERT ON TABLE users FROM app_user;
+			      REVOKE GRANT OPTION FOR SELECT ON TABLE users FROM manager;`,
+			want: []string{"app_user", "manager"},
+		},
+		{
+			name: "pseudo roles and predefined roles are skipped",
+			sql: `GRANT SELECT ON users TO PUBLIC;
+			      GRANT SELECT ON users TO CURRENT_USER, pg_read_all_data, session_user;`,
+			want: nil,
+		},
+		{
+			name: "quoted identifiers keep case, unquoted are folded",
+			sql:  `GRANT SELECT ON users TO "Mixed Case", UPPER_ROLE;`,
+			want: []string{"Mixed Case", "upper_role"},
+		},
+		{
+			name: "policy role lists",
+			sql: `CREATE POLICY p ON users FOR SELECT TO app_user, auditor USING (owner = current_user);
+			      ALTER POLICY p ON users TO tenant;`,
+			want: []string{"app_user", "auditor", "tenant"},
+		},
+		{
+			name: "default privileges grantor and grantee",
+			sql:  `ALTER DEFAULT PRIVILEGES FOR ROLE owner_role IN SCHEMA public GRANT SELECT ON TABLES TO reader;`,
+			want: []string{"owner_role", "reader"},
+		},
+		{
+			name: "legacy GROUP keyword",
+			sql:  `GRANT SELECT ON users TO GROUP admins;`,
+			want: []string{"admins"},
+		},
+		{
+			name: "strings, comments and dollar-quoted bodies are ignored",
+			sql: `-- GRANT SELECT ON users TO commented_out;
+			      DO $$ BEGIN CREATE ROLE in_do_block; GRANT SELECT ON users TO in_do_block; END $$;
+			      INSERT INTO log VALUES ('GRANT SELECT ON users TO in_string');
+			      GRANT SELECT ON users TO real_role;`,
+			want: []string{"real_role"},
+		},
+		{
+			name: "duplicates collapse",
+			sql: `GRANT SELECT ON a TO app_user;
+			      GRANT SELECT ON b TO app_user;`,
+			want: []string{"app_user"},
+		},
+		{
+			name: "no roles",
+			sql:  `CREATE TABLE grants (id int, policy text, to_date date);`,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractReferencedRoles(tt.sql)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractReferencedRoles() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/postgres/role_refs_test.go
+++ b/internal/postgres/role_refs_test.go
@@ -70,6 +70,13 @@ func TestExtractReferencedRoles(t *testing.T) {
 			want: []string{"app_user"},
 		},
 		{
+			name: "comments inside a statement do not split it",
+			sql: `GRANT SELECT ON users TO /* read only */ app_user;
+			      GRANT INSERT ON users -- staff only
+			      TO staff;`,
+			want: []string{"app_user", "staff"},
+		},
+		{
 			name: "no roles",
 			sql:  `CREATE TABLE grants (id int, policy text, to_date date);`,
 			want: nil,

--- a/internal/postgres/role_refs_test.go
+++ b/internal/postgres/role_refs_test.go
@@ -77,6 +77,13 @@ func TestExtractReferencedRoles(t *testing.T) {
 			want: []string{"app_user", "staff"},
 		},
 		{
+			name: "keywords inside quoted identifiers are not list introducers",
+			sql: `GRANT SELECT ON "to" TO app_user;
+			      REVOKE SELECT ON "from" FROM reader;
+			      CREATE POLICY "to" ON "from" TO auditor;`,
+			want: []string{"app_user", "reader", "auditor"},
+		},
+		{
 			name: "no roles",
 			sql:  `CREATE TABLE grants (id int, policy text, to_date date);`,
 			want: nil,


### PR DESCRIPTION
## Summary

Roles are cluster-global and unmanaged, so `pgschema dump` emits `GRANT … TO app_user` but never `CREATE ROLE`. The throwaway plan database had none of the schema's roles, so `plan` failed on the first `GRANT` with `role "app_user" does not exist` — our own dump output could not be consumed by our own plan for anyone who manages privileges. The only stubbing that existed covered `ALTER DEFAULT PRIVILEGES` grantors, and only on `--plan-host` (#553); plain `GRANT … TO x` worked nowhere.

**Fix**

- `ExtractReferencedRoles` (new, `internal/postgres/role_refs.go`) collects grantees of `GRANT`/`REVOKE`, `CREATE/ALTER POLICY … TO` lists, and `ALTER DEFAULT PRIVILEGES FOR ROLE` grantors — skipping `PUBLIC`/`CURRENT_USER`/`CURRENT_ROLE`/`SESSION_USER` and predefined `pg_*` roles, and ignoring strings, comments, and dollar-quoted bodies.
- **Embedded**: every referenced role is created before the desired state is applied; the instance is discarded, so nothing leaks.
- **External**: the ADP-only block is generalised to all referenced roles, keeping the ownership rule from #450's plan — a successful `CREATE ROLE` is the sole proof a role is ours to drop on `Stop()`; `duplicate_object` means it pre-existed and is never touched. Membership is still granted for ADP grantors (the one statement PostgreSQL gates on membership). A plan user without `CREATEROLE` gets a targeted hint instead of a bare permission error.
- **Target validation**: stubbing a role the *target* lacks would only move the failure to apply time with a worse message, so `GeneratePlan` now checks referenced roles against the target's `pg_roles` and fails up front: `role "ghost_role" is referenced by the schema but does not exist on the target database; pgschema does not manage roles, create it on the target first`. (Previously this case tripped the *extension* hint, since both are SQLSTATE 42704.)
- Hoisted the three identical target `ConnectionConfig` literals in `GeneratePlan` into one.
- Docs: `unsupported.mdx` and a new **Roles** section in `plan-db.mdx`.

Roles remain unmanaged — no `CREATE ROLE` tracking — exactly as decided in #450. Existing testdata that seeds roles via `DO $$ CREATE ROLE $$` blocks is untouched; those still exist to seed the target side.

Fixes #450. Also closes the roles half of #584.

## Test plan

- `TestEmbeddedPlanDB_StubsReferencedRoles` (`cmd/plan/role_integration_test.go`): target with object grant, column grant, policy `TO`, and ADP with both grantor and grantee; the desired state repeats them with no `CREATE ROLE`. Fails before the fix with the reporter's exact error, passes after with an empty plan. Second case asserts the missing-on-target error names the role.
- `TestExternalDatabase_StubsReferencedRoles`: stub is present while the provider lives, dropped on `Stop()`, and a pre-existing role on the plan host survives.
- `TestExtractReferencedRoles`: 11 cases (grant option, multi-grantee, column grant, revoke / revoke grant option, pseudo and `pg_*` roles, quoted vs folded identifiers, policy lists, ADP grantor+grantee, `GROUP`, strings/comments/DO blocks ignored, dedup, no false positives on columns named `policy`/`to_date`).

```bash
go test ./cmd/plan -run 'StubsReferencedRoles' -v
go test ./internal/postgres -run TestExtractReferencedRoles
```

Also ran locally, all passing: full `./cmd/plan` (262s), and `PGSCHEMA_TEST_FILTER` for `privilege/`, `default_privilege/`, `create_policy/` on both `TestDiffFromFiles` and `TestPlanAndApply` — these exercise target validation and the duplicate-role path on every case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
